### PR TITLE
Remove dt prefix everywhere

### DIFF
--- a/common.go
+++ b/common.go
@@ -43,7 +43,7 @@ func IntersectSegSeg2D(ap, aq, bp, bq d3.Vec3) (hit bool, s, t float32) {
 //  bmin   Minimum bounds of box B. [(x, y, z)]
 //  bmax   Maximum bounds of box B. [(x, y, z)]
 //  return True if the two AABB's overlap.
-// see dtOverlapBounds
+// see overlapBounds
 func OverlapQuantBounds(amin, amax, bmin, bmax []uint16) bool {
 	if amin[0] > bmax[0] || amax[0] < bmin[0] {
 		return false
@@ -68,7 +68,7 @@ func OverlapQuantBounds(amin, amax, bmin, bmax []uint16) bool {
 //   bmax     Maximum bounds of box B. [(x, y, z)]
 //
 // Return True if the two AABB's overlap.
-// see dtOverlapQuantBounds
+// see overlapQuantBounds
 func OverlapBounds(amin, amax, bmin, bmax []float32) bool {
 	if amin[0] > bmax[0] || amax[0] < bmin[0] {
 		return false

--- a/constants.go
+++ b/constants.go
@@ -7,11 +7,11 @@ const (
 
 const (
 	// The maximum number of vertices per navigation polygon.
-	dtVertsPerPolygon uint32 = 6
+	vertsPerPolygon uint32 = 6
 
 	// A flag that indicates that an off-mesh connection can be traversed in both directions. (Is bidirectional.)
-	dtOffMeshConBidir uint32 = 1
+	offMeshConBidir uint32 = 1
 
 	// The maximum number of user defined area ids.
-	dtMaxAreas int32 = 64
+	maxAreas int32 = 64
 )

--- a/internal/dbg/dbg.go
+++ b/internal/dbg/dbg.go
@@ -21,7 +21,7 @@ func main() {
 	var (
 		f    *os.File
 		err  error
-		mesh *detour.DtNavMesh
+		mesh *detour.NavMesh
 	)
 
 	f, err = os.Open("testdata/navmesh.bin")
@@ -48,30 +48,30 @@ func main() {
 	log.Println("findPath success, path:", path)
 }
 
-func findPath(mesh *detour.DtNavMesh, org, dst d3.Vec3) ([]detour.DtPolyRef, error) {
+func findPath(mesh *detour.NavMesh, org, dst d3.Vec3) ([]detour.PolyRef, error) {
 	var (
-		orgRef, dstRef detour.DtPolyRef       // references of org/dst polygon refs
-		query          *detour.DtNavMeshQuery // the query instance
-		filter         *detour.DtQueryFilter  // filter to use for various queries
+		orgRef, dstRef detour.PolyRef       // references of org/dst polygon refs
+		query          *detour.NavMeshQuery // the query instance
+		filter         *detour.QueryFilter  // filter to use for various queries
 		extents        d3.Vec3                // search distance for polygon search (3 axis)
 		nearestPt      d3.Vec3
-		st             detour.DtStatus
-		path           []detour.DtPolyRef
+		st             detour.Status
+		path           []detour.PolyRef
 	)
 
-	st, query = detour.NewDtNavMeshQuery(mesh, 1000)
-	if detour.DtStatusFailed(st) {
+	st, query = detour.NewNavMeshQuery(mesh, 1000)
+	if detour.StatusFailed(st) {
 		return path, fmt.Errorf("query creation failed with status %v\n", st)
 	}
 	// define the extents vector for the nearest polygon query
 	extents = d3.NewVec3XYZ(0, 2, 0)
 
 	// create a default query filter
-	filter = detour.NewDtQueryFilter()
+	filter = detour.NewQueryFilter()
 
 	// get org polygon reference
 	st, orgRef, nearestPt = query.FindNearestPoly(org, extents, filter)
-	if detour.DtStatusFailed(st) {
+	if detour.StatusFailed(st) {
 		return path, fmt.Errorf("FindNearestPoly failed with %v\n", st)
 	} else if orgRef == 0 {
 		return path, fmt.Errorf("org doesn't intersect any polygons")
@@ -82,7 +82,7 @@ func findPath(mesh *detour.DtNavMesh, org, dst d3.Vec3) ([]detour.DtPolyRef, err
 
 	// get dst polygon reference
 	st, dstRef, nearestPt = query.FindNearestPoly(dst, extents, filter)
-	if detour.DtStatusFailed(st) {
+	if detour.StatusFailed(st) {
 		return path, fmt.Errorf("FindNearestPoly failed with %v\n", st)
 	} else if dstRef == 0 {
 		return path, fmt.Errorf("dst doesn't intersect any polygons")
@@ -95,9 +95,9 @@ func findPath(mesh *detour.DtNavMesh, org, dst d3.Vec3) ([]detour.DtPolyRef, err
 	var (
 		pathCount int32
 	)
-	path = make([]detour.DtPolyRef, 100)
+	path = make([]detour.PolyRef, 100)
 	st = query.FindPath(orgRef, dstRef, org[:], dst[:], filter, &path, &pathCount, 100)
-	if detour.DtStatusFailed(st) {
+	if detour.StatusFailed(st) {
 		return path, fmt.Errorf("query.FindPath failed with %v\n", st)
 	}
 	return path[:pathCount], nil
@@ -121,7 +121,7 @@ func findPath(mesh *detour.DtNavMesh, org, dst d3.Vec3) ([]detour.DtPolyRef, err
 	//poly := ptile.Polys[polyIdx]
 
 	//centroid := make([]float32, 3)
-	//detour.DtCalcPolyCenter(centroid, poly.Verts[:], int32(poly.VertCount), ptile.Verts)
+	//detour.CalcPolyCenter(centroid, poly.Verts[:], int32(poly.VertCount), ptile.Verts)
 	//fmt.Println("poly center: ", centroid)
 
 	////for _, v := range poly.Verts[0:poly.VertCount] {

--- a/node.go
+++ b/node.go
@@ -9,7 +9,7 @@ import (
 	"github.com/aurelien-rainone/math32"
 )
 
-func dtHashRef(a DtPolyRef) uint32 {
+func hashRef(a PolyRef) uint32 {
 	a += ^(a << 15)
 	a ^= (a >> 10)
 	a += (a << 3)
@@ -19,66 +19,66 @@ func dtHashRef(a DtPolyRef) uint32 {
 	return uint32(a)
 }
 
-// DtNodeFlags represent flags associated to a node.
-type DtNodeFlags uint8
+// NodeFlags represent flags associated to a node.
+type NodeFlags uint8
 
 const (
-	dtNodeOpen DtNodeFlags = 1 << iota
-	dtNodeClosed
-	dtNodeParentDetached // parent of the node is not adjacent. Found using raycast.
+	nodeOpen NodeFlags = 1 << iota
+	nodeClosed
+	nodeParentDetached // parent of the node is not adjacent. Found using raycast.
 )
 
-// DtNodeIndex is the index of a node inside the pool.
-type DtNodeIndex uint16
+// NodeIndex is the index of a node inside the pool.
+type NodeIndex uint16
 
 const (
-	dtNullIdx DtNodeIndex = ^DtNodeIndex(0)
+	nullIdx NodeIndex = ^NodeIndex(0)
 )
 
 const (
-	dtNodeParentBits uint32 = 24
-	dtNodeStateBits  uint32 = 2
+	nodeParentBits uint32 = 24
+	nodeStateBits  uint32 = 2
 )
 
-// DtNode represents a node in a weighted graph.
-type DtNode struct {
+// Node represents a node in a weighted graph.
+type Node struct {
 	Pos   d3.Vec3 // Position of the node.
 	Cost  float32 // Cost from previous node to current node.
 	Total float32 // Cost up to the node.
-	//unsigned int pidx : DT_NODE_PARENT_BITS;	// Index to parent node.
-	//unsigned int state : DT_NODE_STATE_BITS;	// extra state information. A polyRef can have multiple nodes with different extra info. see DT_MAX_STATES_PER_NODE
-	//unsigned int flags : 3;						// Node flags. A combination of dtNodeFlags.
+	//unsigned int pidx : nodeParentBits;	// Index to parent node.
+	//unsigned int state : DT_NODE_STATE_BITS;	// extra state information. A polyRef can have multiple nodes with different extra info. see maxStatesPerNode
+	//unsigned int flags : 3;						// Node flags. A combination of NodeFlags.
 
-	// fucking C bitfields!!! as we allocate the dtNode ourselves, we can always use:
+	// fucking C bitfields!!! as we allocate the Node ourselves, we can always use:
 	PIdx  uint32
 	State uint8
 	//Flags uint8
-	Flags DtNodeFlags
-	ID    DtPolyRef // Polygon ref the node corresponds to.
+	Flags NodeFlags
+	ID    PolyRef // Polygon ref the node corresponds to.
 }
 
-func newDtNode() DtNode {
-	return DtNode{
+func newNode() Node {
+	return Node{
 		Pos: d3.NewVec3(),
 	}
 }
 
 const (
-	dtMaxStatesPerNode int32 = 1 << dtNodeStateBits // number of extra states per node. See dtNode::state
+	maxStatesPerNode int32 = 1 << nodeStateBits // number of extra states per node. See Node::state
 )
 
-// DtNodePool is a pool of nodes, it allocated them and allows
+// NodePool is a pool of nodes, it allocated them and allows
 // them to be reused.
-type DtNodePool struct {
-	nodes       []DtNode
-	first, next []DtNodeIndex
+type NodePool struct {
+	nodes       []Node
+	first, next []NodeIndex
 	maxNodes    int32
 	hashSize    int32
 	nodeCount   int32
 }
 
-func newDtNodePool(maxNodes, hashSize int32) *DtNodePool {
-	np := &DtNodePool{
+func newNodePool(maxNodes, hashSize int32) *NodePool {
+	np := &NodePool{
 		maxNodes: maxNodes,
 		hashSize: hashSize,
 	}
@@ -88,49 +88,49 @@ func newDtNodePool(maxNodes, hashSize int32) *DtNodePool {
 	// pidx is special as 0 means "none" and 1 is the first node.
 	// For that reason we have 1 fewer nodes available than the
 	// number of values it can contain.
-	assert.True(np.maxNodes > 0 && np.maxNodes <= int32(dtNullIdx) &&
-		np.maxNodes <= (1<<dtNodeParentBits)-1, "DtNodePool, max nodes check failed")
+	assert.True(np.maxNodes > 0 && np.maxNodes <= int32(nullIdx) &&
+		np.maxNodes <= (1<<nodeParentBits)-1, "NodePool, max nodes check failed")
 
-	np.nodes = make([]DtNode, np.maxNodes)
+	np.nodes = make([]Node, np.maxNodes)
 	for i := range np.nodes {
-		np.nodes[i] = newDtNode()
+		np.nodes[i] = newNode()
 	}
-	np.next = make([]DtNodeIndex, np.maxNodes)
-	np.first = make([]DtNodeIndex, hashSize)
+	np.next = make([]NodeIndex, np.maxNodes)
+	np.first = make([]NodeIndex, hashSize)
 
 	assert.True(len(np.nodes) > 0, "Nodes should not be empty")
 	assert.True(len(np.next) > 0, "Next should not be empty")
 	assert.True(len(np.first) > 0, "First should not be empty")
 
 	for idx := range np.first {
-		np.first[idx] = dtNullIdx
+		np.first[idx] = nullIdx
 	}
 	for idx := range np.next {
-		np.next[idx] = dtNullIdx
+		np.next[idx] = nullIdx
 	}
 	return np
 }
 
 // Clear clears the node pool.
-func (np *DtNodePool) Clear() {
+func (np *NodePool) Clear() {
 	assert.True(int(np.hashSize) == len(np.first), "np.HashSize == len(np.First)")
 	for idx := range np.first {
-		np.first[idx] = dtNullIdx
+		np.first[idx] = nullIdx
 	}
 	np.nodeCount = 0
 }
 
-// Node returns a dtNode by ref and extra state information. If
+// Node returns a Node by ref and extra state information. If
 // there is none then allocate. There can be more than one node
 // for the same polyRef but with different extra state
 // information
-func (np *DtNodePool) Node(id DtPolyRef, state uint8) *DtNode {
-	bucket := dtHashRef(id) & uint32(np.hashSize-1)
+func (np *NodePool) Node(id PolyRef, state uint8) *Node {
+	bucket := hashRef(id) & uint32(np.hashSize-1)
 
-	var i DtNodeIndex
+	var i NodeIndex
 	i = np.first[bucket]
-	var node *DtNode
-	for i != dtNullIdx {
+	var node *Node
+	for i != nullIdx {
 		if np.nodes[i].ID == id && np.nodes[i].State == state {
 			return &np.nodes[i]
 		}
@@ -141,7 +141,7 @@ func (np *DtNodePool) Node(id DtPolyRef, state uint8) *DtNode {
 		return nil
 	}
 
-	i = DtNodeIndex(np.nodeCount)
+	i = NodeIndex(np.nodeCount)
 	np.nodeCount++
 
 	// Init node
@@ -161,10 +161,10 @@ func (np *DtNodePool) Node(id DtPolyRef, state uint8) *DtNode {
 
 // FindNode finds the node that corresponds to the given polygon
 // reference and having the given state
-func (np *DtNodePool) FindNode(id DtPolyRef, state uint8) *DtNode {
-	bucket := dtHashRef(id) & uint32(np.hashSize-1)
+func (np *NodePool) FindNode(id PolyRef, state uint8) *Node {
+	bucket := hashRef(id) & uint32(np.hashSize-1)
 	i := np.first[bucket]
-	for i != dtNullIdx {
+	for i != nullIdx {
 		if np.nodes[i].ID == id && np.nodes[i].State == state {
 			return &np.nodes[i]
 		}
@@ -178,13 +178,13 @@ func (np *DtNodePool) FindNode(id DtPolyRef, state uint8) *DtNode {
 //
 // Note: No more than maxNodes will be returned (nodes should
 // have at least maxNodes elements)
-func (np *DtNodePool) FindNodes(id DtPolyRef, nodes []*DtNode, maxNodes int32) uint32 {
+func (np *NodePool) FindNodes(id PolyRef, nodes []*Node, maxNodes int32) uint32 {
 	assert.True(len(nodes) >= int(maxNodes), "nodes should contain at least maxNodes elements")
 
 	var n uint32
-	bucket := dtHashRef(id) & uint32(np.hashSize-1)
+	bucket := hashRef(id) & uint32(np.hashSize-1)
 	i := np.first[bucket]
-	for i != dtNullIdx {
+	for i != nullIdx {
 		if np.nodes[i].ID == id {
 			if n >= uint32(maxNodes) {
 				return n
@@ -198,7 +198,7 @@ func (np *DtNodePool) FindNodes(id DtPolyRef, nodes []*DtNode, maxNodes int32) u
 }
 
 // NodeIdx returns the index of the given node.
-func (np *DtNodePool) NodeIdx(node *DtNode) uint32 {
+func (np *NodePool) NodeIdx(node *Node) uint32 {
 	if node == nil {
 		return 0
 	}
@@ -212,7 +212,7 @@ func (np *DtNodePool) NodeIdx(node *DtNode) uint32 {
 }
 
 // NodeAtIdx returns the node at given index.
-func (np *DtNodePool) NodeAtIdx(idx int32) *DtNode {
+func (np *NodePool) NodeAtIdx(idx int32) *Node {
 	if idx == 0 {
 		return nil
 	}
@@ -221,36 +221,36 @@ func (np *DtNodePool) NodeAtIdx(idx int32) *DtNode {
 
 // MemUsed returns the number of bytes currently in use in this
 // node pool.
-func (np *DtNodePool) MemUsed() int32 {
+func (np *NodePool) MemUsed() int32 {
 	log.Fatal("use of unsafe in getMemUsed")
 	return int32(unsafe.Sizeof(*np)) +
-		int32(unsafe.Sizeof(DtNode{}))*np.maxNodes +
-		int32(unsafe.Sizeof(DtNodeIndex(0)))*np.maxNodes +
-		int32(unsafe.Sizeof(DtNodeIndex(0)))*np.hashSize
+		int32(unsafe.Sizeof(Node{}))*np.maxNodes +
+		int32(unsafe.Sizeof(NodeIndex(0)))*np.maxNodes +
+		int32(unsafe.Sizeof(NodeIndex(0)))*np.hashSize
 }
 
 // MaxNodes returns the maximum number of nodes the pool can
 // contain.
-func (np *DtNodePool) MaxNodes() int32 {
+func (np *NodePool) MaxNodes() int32 {
 	return np.maxNodes
 }
 
 // HashSize returns the hash size.
-func (np *DtNodePool) HashSize() int32 {
+func (np *NodePool) HashSize() int32 {
 	return np.hashSize
 }
 
 // First returns the index of the first node.
-func (np *DtNodePool) First(bucket int32) DtNodeIndex {
+func (np *NodePool) First(bucket int32) NodeIndex {
 	return np.first[bucket]
 }
 
 // Next returns the next node index after the given one.
-func (np *DtNodePool) Next(i int32) DtNodeIndex {
+func (np *NodePool) Next(i int32) NodeIndex {
 	return np.next[i]
 }
 
 // NodeCount returns the current node count in the pool.
-func (np *DtNodePool) NodeCount() int32 {
+func (np *NodePool) NodeCount() int32 {
 	return np.nodeCount
 }

--- a/nodequeue.go
+++ b/nodequeue.go
@@ -7,25 +7,25 @@ import (
 	"github.com/aurelien-rainone/assertgo"
 )
 
-type dtNodeQueue struct {
-	heap     []*DtNode
+type nodeQueue struct {
+	heap     []*Node
 	capacity int32
 	size     int32
 }
 
-func newDtNodeQueue(n int32) *dtNodeQueue {
-	q := &dtNodeQueue{}
+func newnodeQueue(n int32) *nodeQueue {
+	q := &nodeQueue{}
 
 	q.capacity = n
-	assert.True(q.capacity > 0, "dtNodeQueue capacity must be > 0")
+	assert.True(q.capacity > 0, "nodeQueue capacity must be > 0")
 
-	q.heap = make([]*DtNode, q.capacity+1)
+	q.heap = make([]*Node, q.capacity+1)
 	assert.True(len(q.heap) > 0, "allocation error")
 
 	return q
 }
 
-func (q *dtNodeQueue) bubbleUp(i int32, node *DtNode) {
+func (q *nodeQueue) bubbleUp(i int32, node *Node) {
 	parent := (i - 1) / 2
 	// note: (index > 0) means there is a parent
 	for (i > 0) && (q.heap[parent].Total > node.Total) {
@@ -36,7 +36,7 @@ func (q *dtNodeQueue) bubbleUp(i int32, node *DtNode) {
 	q.heap[i] = node
 }
 
-func (q *dtNodeQueue) trickleDown(i int32, node *DtNode) {
+func (q *nodeQueue) trickleDown(i int32, node *Node) {
 	child := (i * 2) + 1
 	for child < q.size {
 		if ((child + 1) < q.size) &&
@@ -50,27 +50,27 @@ func (q *dtNodeQueue) trickleDown(i int32, node *DtNode) {
 	q.bubbleUp(i, node)
 }
 
-func (q *dtNodeQueue) clear() {
+func (q *nodeQueue) clear() {
 	q.size = 0
 }
 
-func (q *dtNodeQueue) top() *DtNode {
+func (q *nodeQueue) top() *Node {
 	return q.heap[0]
 }
 
-func (q *dtNodeQueue) pop() *DtNode {
+func (q *nodeQueue) pop() *Node {
 	result := q.heap[0]
 	q.size--
 	q.trickleDown(0, q.heap[q.size])
 	return result
 }
 
-func (q *dtNodeQueue) push(node *DtNode) {
+func (q *nodeQueue) push(node *Node) {
 	q.size++
 	q.bubbleUp(q.size-1, node)
 }
 
-func (q *dtNodeQueue) modify(node *DtNode) {
+func (q *nodeQueue) modify(node *Node) {
 	for i := int32(0); i < q.size; i++ {
 		if q.heap[i] == node {
 			q.bubbleUp(i, node)
@@ -79,12 +79,12 @@ func (q *dtNodeQueue) modify(node *DtNode) {
 	}
 }
 
-func (q *dtNodeQueue) empty() bool {
+func (q *nodeQueue) empty() bool {
 	return q.size == 0
 }
 
-func (q *dtNodeQueue) memUsed() int32 {
+func (q *nodeQueue) memUsed() int32 {
 	log.Fatal("use of unsafe in memUsed")
 	return int32(unsafe.Sizeof(*q)) +
-		int32(unsafe.Sizeof(DtNode{}))*(q.capacity+1)
+		int32(unsafe.Sizeof(Node{}))*(q.capacity+1)
 }

--- a/poly.go
+++ b/poly.go
@@ -2,19 +2,19 @@ package detour
 
 import "github.com/aurelien-rainone/gogeo/f32/d3"
 
-// DtPoly defines a polygon within a DtMeshTile object.
-type DtPoly struct {
+// Poly defines a polygon within a MeshTile object.
+type Poly struct {
 	// FirstLink is the index to first link in linked list.
-	// (Or DT_NULL_LINK if there is no link.)
+	// (Or nullLink if there is no link.)
 	FirstLink uint32
 
 	// Verts are the indices of the polygon's vertices.
-	// The actual vertices are located in DtMeshTile.Verts.
-	Verts [dtVertsPerPolygon]uint16
+	// The actual vertices are located in MeshTile.Verts.
+	Verts [vertsPerPolygon]uint16
 
 	// Neis is packed data representing neighbor polygons
 	// references and flags for each edge.
-	Neis [dtVertsPerPolygon]uint16
+	Neis [vertsPerPolygon]uint16
 
 	// Flags is an user-defined polygon flags.
 	Flags uint16
@@ -30,31 +30,31 @@ type DtPoly struct {
 	AreaAndType uint8
 }
 
-// SetArea sets the user defined area id. (limit: < DT_MAX_AREAS)
-func (p *DtPoly) SetArea(a uint8) {
+// SetArea sets the user defined area id. (limit: < maxAreas)
+func (p *Poly) SetArea(a uint8) {
 	p.AreaAndType = (p.AreaAndType & 0xc0) | (a & 0x3f)
 }
 
-// SetType sets the polygon type. (see: DtPolyTypes.)
-func (p *DtPoly) SetType(t uint8) {
+// SetType sets the polygon type. (see: polyTypes.)
+func (p *Poly) SetType(t uint8) {
 	p.AreaAndType = (p.AreaAndType & 0x3f) | (t << 6)
 }
 
 // Area returns the user defined area id.
-func (p *DtPoly) Area() uint8 {
+func (p *Poly) Area() uint8 {
 	return p.AreaAndType & 0x3f
 }
 
-// Type returns the polygon type. (see: DtPolyTypes)
-func (p *DtPoly) Type() uint8 {
+// Type returns the polygon type. (see: polyTypes)
+func (p *Poly) Type() uint8 {
 	return p.AreaAndType >> 6
 }
 
-// DtCalcPolyCenter derives and returns the centroid of a convex polygon.
+// CalcPolyCenter derives and returns the centroid of a convex polygon.
 //  idx     polygon indices. [(vertIndex) * nidx]
 //  nidx    number of indices in the polygon. (limit: >= 3)
 //  verts   polygon vertices. [(x, y, z) * vertCount]
-func DtCalcPolyCenter(idx []uint16, nidx int32, verts []float32) d3.Vec3 {
+func CalcPolyCenter(idx []uint16, nidx int32, verts []float32) d3.Vec3 {
 	tc := d3.NewVec3()
 	var j int32
 	for j = 0; j < nidx; j++ {

--- a/poly_test.go
+++ b/poly_test.go
@@ -8,12 +8,12 @@ import (
 
 func TestCalcPolyCenter(t *testing.T) {
 	var (
-		mesh *DtNavMesh
+		mesh *NavMesh
 		err  error
 	)
 
 	polyTests := []struct {
-		ref  DtPolyRef
+		ref  PolyRef
 		want d3.Vec3
 	}{
 		{0x440000, d3.Vec3{3.6002522, 0.189468, 10.873747}},
@@ -26,11 +26,11 @@ func TestCalcPolyCenter(t *testing.T) {
 	for _, tt := range polyTests {
 
 		var (
-			tile *DtMeshTile
-			poly *DtPoly
+			tile *MeshTile
+			poly *Poly
 		)
 		mesh.TileAndPolyByRef(tt.ref, &tile, &poly)
-		got := DtCalcPolyCenter(poly.Verts[:], int32(poly.VertCount), tile.Verts)
+		got := CalcPolyCenter(poly.Verts[:], int32(poly.VertCount), tile.Verts)
 		if !got.Approx(tt.want) {
 			t.Errorf("want centroid of poly 0x%x = %v, got %v", tt.ref, tt.want, got)
 		}
@@ -39,7 +39,7 @@ func TestCalcPolyCenter(t *testing.T) {
 
 func TestFindNearestPolySpecialCases(t *testing.T) {
 	var (
-		mesh *DtNavMesh
+		mesh *NavMesh
 		err  error
 	)
 
@@ -47,20 +47,20 @@ func TestFindNearestPolySpecialCases(t *testing.T) {
 		msg     string    // test description
 		pt      d3.Vec3   // point
 		ext     d3.Vec3   // search extents
-		wantSt  DtStatus  // expected status
-		wantRef DtPolyRef // expected ref (if query succeeded)
+		wantSt  Status  // expected status
+		wantRef PolyRef // expected ref (if query succeeded)
 	}{
 		{
 			"search box does not intersect any poly",
-			d3.Vec3{-5, 0, 10}, d3.Vec3{1, 1, 1}, DtSuccess, 0,
+			d3.Vec3{-5, 0, 10}, d3.Vec3{1, 1, 1}, Success, 0,
 		},
 		{
 			"unallocated center vector",
-			d3.Vec3{}, d3.Vec3{1, 1, 1}, DtFailure | DtInvalidParam, 0,
+			d3.Vec3{}, d3.Vec3{1, 1, 1}, Failure | InvalidParam, 0,
 		},
 		{
 			"unallocated extents vector",
-			d3.Vec3{0, 0, 0}, d3.Vec3{}, DtFailure | DtInvalidParam, 0,
+			d3.Vec3{0, 0, 0}, d3.Vec3{}, Failure | InvalidParam, 0,
 		},
 	}
 
@@ -69,20 +69,20 @@ func TestFindNearestPolySpecialCases(t *testing.T) {
 
 	for _, tt := range pathTests {
 		var (
-			q   *DtNavMeshQuery
-			st  DtStatus
-			ref DtPolyRef
+			q   *NavMeshQuery
+			st  Status
+			ref PolyRef
 		)
 
-		st, q = NewDtNavMeshQuery(mesh, 100)
-		f := NewDtQueryFilter()
+		st, q = NewNavMeshQuery(mesh, 100)
+		f := NewQueryFilter()
 
 		st, ref, _ = q.FindNearestPoly(tt.pt, tt.ext, f)
 		if st != tt.wantSt {
 			t.Errorf("%s, want status 0x%x, got 0x%x", tt.msg, tt.wantSt, st)
 		}
 
-		if DtStatusSucceed(st) && ref != tt.wantRef {
+		if StatusSucceed(st) && ref != tt.wantRef {
 			t.Errorf("%s, want ref 0x%x, got 0x%x", tt.msg, tt.wantRef, ref)
 		}
 	}

--- a/polyquery.go
+++ b/polyquery.go
@@ -8,25 +8,25 @@ import (
 )
 
 // Provides custom polygon query behavior.
-// Used by dtNavMeshQuery.queryPolygons.
-type dtPolyQuery interface {
+// Used by NavMeshQuery.queryPolygons.
+type polyQuery interface {
 
 	// Called for each batch of unique polygons touched by the search area in
-	// dtNavMeshQuery::queryPolygons. This can be called multiple times for a
+	// NavMeshQuery::queryPolygons. This can be called multiple times for a
 	// single query.
-	process(tile *DtMeshTile, polys []*DtPoly, refs []DtPolyRef, count int32)
+	process(tile *MeshTile, polys []*Poly, refs []PolyRef, count int32)
 }
 
-type dtFindNearestPolyQuery struct {
-	query              *DtNavMeshQuery
+type findNearestPolyQuery struct {
+	query              *NavMeshQuery
 	center             d3.Vec3
 	nearestDistanceSqr float32
-	nearestRef         DtPolyRef
+	nearestRef         PolyRef
 	nearestPoint       d3.Vec3
 }
 
-func newDtFindNearestPolyQuery(query *DtNavMeshQuery, center d3.Vec3) *dtFindNearestPolyQuery {
-	return &dtFindNearestPolyQuery{
+func newFindNearestPolyQuery(query *NavMeshQuery, center d3.Vec3) *findNearestPolyQuery {
+	return &findNearestPolyQuery{
 		query:              query,
 		center:             center,
 		nearestDistanceSqr: math32.MaxFloat32,
@@ -35,7 +35,7 @@ func newDtFindNearestPolyQuery(query *DtNavMeshQuery, center d3.Vec3) *dtFindNea
 	}
 }
 
-func (q *dtFindNearestPolyQuery) process(tile *DtMeshTile, polys []*DtPoly, refs []DtPolyRef, count int32) {
+func (q *findNearestPolyQuery) process(tile *MeshTile, polys []*Poly, refs []PolyRef, count int32) {
 
 	for i := int32(0); i < count; i++ {
 		ref := refs[i]
@@ -70,16 +70,16 @@ func (q *dtFindNearestPolyQuery) process(tile *DtMeshTile, polys []*DtPoly, refs
 	}
 }
 
-type dtCollectPolysQuery struct {
-	polys        []DtPolyRef
+type collectPolysQuery struct {
+	polys        []PolyRef
 	maxPolys     int32
 	numCollected int32
 	overflow     bool
 }
 
-func newDtCollectPolysQuery(polys []DtPolyRef, maxPolys int32) *dtCollectPolysQuery {
+func newCollectPolysQuery(polys []PolyRef, maxPolys int32) *collectPolysQuery {
 
-	return &dtCollectPolysQuery{
+	return &collectPolysQuery{
 		polys:        polys,
 		maxPolys:     maxPolys,
 		numCollected: 0,
@@ -87,7 +87,7 @@ func newDtCollectPolysQuery(polys []DtPolyRef, maxPolys int32) *dtCollectPolysQu
 	}
 }
 
-func (q *dtCollectPolysQuery) process(tile *DtMeshTile, polys []*DtPoly, refs []DtPolyRef, count int32) {
+func (q *collectPolysQuery) process(tile *MeshTile, polys []*Poly, refs []PolyRef, count int32) {
 
 	numLeft := q.maxPolys - q.numCollected
 	toCopy := count
@@ -96,9 +96,7 @@ func (q *dtCollectPolysQuery) process(tile *DtMeshTile, polys []*DtPoly, refs []
 		toCopy = numLeft
 	}
 
-	log.Fatal("to be checked")
-	//memcpy(m_polys + m_numCollected, refs, (size_t)toCopy * sizeof(DtPolyRef));
-	//TODO: check that...
+	log.Fatal("untested")
 	copy(q.polys[q.numCollected:], refs[0:toCopy])
 	q.numCollected += toCopy
 }

--- a/query.go
+++ b/query.go
@@ -16,9 +16,9 @@ const (
 	HScale float32 = 0.999
 )
 
-// DtNavMeshQuery provides the ability to perform pathfinding related queries
+// NavMeshQuery provides the ability to perform pathfinding related queries
 // against a navigation mesh.
-type DtNavMeshQuery struct {
+type NavMeshQuery struct {
 
 	/////@}
 	///// @name Sliced Pathfinding Functions
@@ -36,15 +36,15 @@ type DtNavMeshQuery struct {
 	/////  @param[in]		filter		The polygon filter to apply to the query.
 	/////  @param[in]		options		query options (see: #dtFindPathOptions)
 	///// @returns The status flags for the query.
-	//dtStatus initSlicedFindPath(DtPolyRef startRef, DtPolyRef endRef,
+	//Status initSlicedFindPath(PolyRef startRef, PolyRef endRef,
 	//const float* startPos, const float* endPos,
-	//const dtQueryFilter* filter, const unsigned int options = 0);
+	//const QueryFilter* filter, const unsigned int options = 0);
 
 	///// Updates an in-progress sliced path query.
 	/////  @param[in]		maxIter		The maximum number of iterations to perform.
 	/////  @param[out]	doneIters	The actual number of iterations completed. [opt]
 	///// @returns The status flags for the query.
-	//dtStatus updateSlicedFindPath(const int maxIter, int* doneIters);
+	//Status updateSlicedFindPath(const int maxIter, int* doneIters);
 
 	///// Finalizes and returns the results of a sliced path query.
 	/////  @param[out]	path		An ordered list of polygon references representing the path. (Start to end.)
@@ -52,7 +52,7 @@ type DtNavMeshQuery struct {
 	/////  @param[out]	pathCount	The number of polygons returned in the @p path array.
 	/////  @param[in]		maxPath		The max number of polygons the path array can hold. [Limit: >= 1]
 	///// @returns The status flags for the query.
-	//dtStatus finalizeSlicedFindPath(DtPolyRef* path, int* pathCount, const int maxPath);
+	//Status finalizeSlicedFindPath(PolyRef* path, int* pathCount, const int maxPath);
 
 	///// Finalizes and returns the results of an incomplete sliced path query, returning the path to the furthest
 	///// polygon on the existing path that was visited during the search.
@@ -63,8 +63,8 @@ type DtNavMeshQuery struct {
 	/////  @param[out]	pathCount		The number of polygons returned in the @p path array.
 	/////  @param[in]		maxPath			The max number of polygons the @p path array can hold. [Limit: >= 1]
 	///// @returns The status flags for the query.
-	//dtStatus finalizeSlicedFindPathPartial(const DtPolyRef* existing, const int existingSize,
-	//DtPolyRef* path, int* pathCount, const int maxPath);
+	//Status finalizeSlicedFindPathPartial(const PolyRef* existing, const int existingSize,
+	//PolyRef* path, int* pathCount, const int maxPath);
 
 	/////@}
 	///// @name Dijkstra Search Functions
@@ -82,9 +82,9 @@ type DtNavMeshQuery struct {
 	/////  @param[out]	resultCount		The number of polygons found. [opt]
 	/////  @param[in]		maxResult		The maximum number of polygons the result arrays can hold.
 	///// @returns The status flags for the query.
-	//dtStatus findPolysAroundCircle(DtPolyRef startRef, const float* centerPos, const float radius,
-	//const dtQueryFilter* filter,
-	//DtPolyRef* resultRef, DtPolyRef* resultParent, float* resultCost,
+	//Status findPolysAroundCircle(PolyRef startRef, const float* centerPos, const float radius,
+	//const QueryFilter* filter,
+	//PolyRef* resultRef, PolyRef* resultParent, float* resultCost,
 	//int* resultCount, const int maxResult) const;
 
 	///// Finds the polygons along the naviation graph that touch the specified convex polygon.
@@ -100,9 +100,9 @@ type DtNavMeshQuery struct {
 	/////  @param[out]	resultCount		The number of polygons found.
 	/////  @param[in]		maxResult		The maximum number of polygons the result arrays can hold.
 	///// @returns The status flags for the query.
-	//dtStatus findPolysAroundShape(DtPolyRef startRef, const float* verts, const int nverts,
-	//const dtQueryFilter* filter,
-	//DtPolyRef* resultRef, DtPolyRef* resultParent, float* resultCost,
+	//Status findPolysAroundShape(PolyRef startRef, const float* verts, const int nverts,
+	//const QueryFilter* filter,
+	//PolyRef* resultRef, PolyRef* resultParent, float* resultCost,
 	//int* resultCount, const int maxResult) const;
 
 	///// Gets a path from the explored nodes in the previous search.
@@ -112,12 +112,12 @@ type DtNavMeshQuery struct {
 	/////  @param[out]	pathCount	The number of polygons returned in the @p path array.
 	/////  @param[in]		maxPath		The maximum number of polygons the @p path array can hold. [Limit: >= 0]
 	/////  @returns		The status flags. Returns DT_FAILURE | DT_INVALID_PARAM if any parameter is wrong, or if
-	/////  				@p endRef was not explored in the previous search. Returns DT_SUCCESS | DT_BUFFER_TOO_SMALL
+	/////  				@p endRef was not explored in the previous search. Returns Success | DT_BUFFER_TOO_SMALL
 	/////  				if @p path cannot contain the entire path. In this case it is filled to capacity with a partial path.
-	/////  				Otherwise returns DT_SUCCESS.
+	/////  				Otherwise returns Success.
 	/////  @remarks		The result of this function depends on the state of the query object. For that reason it should only
 	/////  				be used immediately after one of the two Dijkstra searches, findPolysAroundCircle or findPolysAroundShape.
-	//dtStatus getPathFromDijkstraSearch(DtPolyRef endRef, DtPolyRef* path, int* pathCount, int maxPath) const;
+	//Status getPathFromDijkstraSearch(PolyRef endRef, PolyRef* path, int* pathCount, int maxPath) const;
 
 	///// @}
 	///// @name Local Query Functions
@@ -130,9 +130,9 @@ type DtNavMeshQuery struct {
 	/////  @param[out]	nearestRef	The reference id of the nearest polygon.
 	/////  @param[out]	nearestPt	The nearest point on the polygon. [opt] [(x, y, z)]
 	///// @returns The status flags for the query.
-	//dtStatus findNearestPoly(const float* center, const float* extents,
-	//const dtQueryFilter* filter,
-	//DtPolyRef* nearestRef, float* nearestPt) const;
+	//Status findNearestPoly(const float* center, const float* extents,
+	//const QueryFilter* filter,
+	//PolyRef* nearestRef, float* nearestPt) const;
 
 	///// Finds the non-overlapping navigation polygons in the local neighbourhood around the center position.
 	/////  @param[in]		startRef		The reference id of the polygon where the search starts.
@@ -145,9 +145,9 @@ type DtNavMeshQuery struct {
 	/////  @param[out]	resultCount		The number of polygons found.
 	/////  @param[in]		maxResult		The maximum number of polygons the result arrays can hold.
 	///// @returns The status flags for the query.
-	//dtStatus findLocalNeighbourhood(DtPolyRef startRef, const float* centerPos, const float radius,
-	//const dtQueryFilter* filter,
-	//DtPolyRef* resultRef, DtPolyRef* resultParent,
+	//Status findLocalNeighbourhood(PolyRef startRef, const float* centerPos, const float radius,
+	//const QueryFilter* filter,
+	//PolyRef* resultRef, PolyRef* resultParent,
 	//int* resultCount, const int maxResult) const;
 
 	///// Moves from the start to the end position constrained to the navigation mesh.
@@ -160,9 +160,9 @@ type DtNavMeshQuery struct {
 	/////  @param[out]	visitedCount	The number of polygons visited during the move.
 	/////  @param[in]		maxVisitedSize	The maximum number of polygons the @p visited array can hold.
 	///// @returns The status flags for the query.
-	//dtStatus moveAlongSurface(DtPolyRef startRef, const float* startPos, const float* endPos,
-	//const dtQueryFilter* filter,
-	//float* resultPos, DtPolyRef* visited, int* visitedCount, const int maxVisitedSize) const;
+	//Status moveAlongSurface(PolyRef startRef, const float* startPos, const float* endPos,
+	//const QueryFilter* filter,
+	//float* resultPos, PolyRef* visited, int* visitedCount, const int maxVisitedSize) const;
 
 	///// Casts a 'walkability' ray along the surface of the navigation mesh from
 	///// the start position toward the end position.
@@ -178,9 +178,9 @@ type DtNavMeshQuery struct {
 	/////  @param[out]	pathCount	The number of visited polygons. [opt]
 	/////  @param[in]		maxPath		The maximum number of polygons the @p path array can hold.
 	///// @returns The status flags for the query.
-	//dtStatus raycast(DtPolyRef startRef, const float* startPos, const float* endPos,
-	//const dtQueryFilter* filter,
-	//float* t, float* hitNormal, DtPolyRef* path, int* pathCount, const int maxPath) const;
+	//Status raycast(PolyRef startRef, const float* startPos, const float* endPos,
+	//const QueryFilter* filter,
+	//float* t, float* hitNormal, PolyRef* path, int* pathCount, const int maxPath) const;
 
 	///// Casts a 'walkability' ray along the surface of the navigation mesh from
 	///// the start position toward the end position.
@@ -193,9 +193,9 @@ type DtNavMeshQuery struct {
 	/////  @param[out]	hit			Pointer to a raycast hit structure which will be filled by the results.
 	/////  @param[in]		prevRef		parent of start ref. Used during for cost calculation [opt]
 	///// @returns The status flags for the query.
-	//dtStatus raycast(DtPolyRef startRef, const float* startPos, const float* endPos,
-	//const dtQueryFilter* filter, const unsigned int options,
-	//dtRaycastHit* hit, DtPolyRef prevRef = 0) const;
+	//Status raycast(PolyRef startRef, const float* startPos, const float* endPos,
+	//const QueryFilter* filter, const unsigned int options,
+	//dtRaycastHit* hit, PolyRef prevRef = 0) const;
 
 	///// Finds the distance from the specified position to the nearest polygon wall.
 	/////  @param[in]		startRef		The reference id of the polygon containing @p centerPos.
@@ -207,8 +207,8 @@ type DtNavMeshQuery struct {
 	/////  @param[out]	hitNormal		The normalized ray formed from the wall point to the
 	/////  								source point. [(x, y, z)]
 	///// @returns The status flags for the query.
-	//dtStatus findDistanceToWall(DtPolyRef startRef, const float* centerPos, const float maxRadius,
-	//const dtQueryFilter* filter,
+	//Status findDistanceToWall(PolyRef startRef, const float* centerPos, const float maxRadius,
+	//const QueryFilter* filter,
 	//float* hitDist, float* hitPos, float* hitNormal) const;
 
 	///// Returns the segments for the specified polygon, optionally including portals.
@@ -220,8 +220,8 @@ type DtNavMeshQuery struct {
 	/////  @param[out]	segmentCount	The number of segments returned.
 	/////  @param[in]		maxSegments		The maximum number of segments the result arrays can hold.
 	///// @returns The status flags for the query.
-	//dtStatus getPolyWallSegments(DtPolyRef ref, const dtQueryFilter* filter,
-	//float* segmentVerts, DtPolyRef* segmentRefs, int* segmentCount,
+	//Status getPolyWallSegments(PolyRef ref, const QueryFilter* filter,
+	//float* segmentVerts, PolyRef* segmentRefs, int* segmentCount,
 	//const int maxSegments) const;
 
 	///// Returns random location on navmesh.
@@ -231,8 +231,8 @@ type DtNavMeshQuery struct {
 	/////  @param[out]	randomRef		The reference id of the random location.
 	/////  @param[out]	randomPt		The random location.
 	///// @returns The status flags for the query.
-	//dtStatus findRandomPoint(const dtQueryFilter* filter, float (*frand)(),
-	//DtPolyRef* randomRef, float* randomPt) const;
+	//Status findRandomPoint(const QueryFilter* filter, float (*frand)(),
+	//PolyRef* randomRef, float* randomPt) const;
 
 	///// Returns random location on navmesh within the reach of specified location.
 	///// Polygons are chosen weighted by area. The search runs in linear related to number of polygon.
@@ -244,16 +244,16 @@ type DtNavMeshQuery struct {
 	/////  @param[out]	randomRef		The reference id of the random location.
 	/////  @param[out]	randomPt		The random location. [(x, y, z)]
 	///// @returns The status flags for the query.
-	//dtStatus findRandomPointAroundCircle(DtPolyRef startRef, const float* centerPos, const float maxRadius,
-	//const dtQueryFilter* filter, float (*frand)(),
-	//DtPolyRef* randomRef, float* randomPt) const;
+	//Status findRandomPointAroundCircle(PolyRef startRef, const float* centerPos, const float maxRadius,
+	//const QueryFilter* filter, float (*frand)(),
+	//PolyRef* randomRef, float* randomPt) const;
 
 	///// Gets the height of the polygon at the provided position using the height detail. (Most accurate.)
 	/////  @param[in]		ref			The reference id of the polygon.
 	/////  @param[in]		pos			A position within the xz-bounds of the polygon. [(x, y, z)]
 	/////  @param[out]	height		The height at the surface of the polygon.
 	///// @returns The status flags for the query.
-	//dtStatus getPolyHeight(DtPolyRef ref, const float* pos, float* height) const;
+	//Status getPolyHeight(PolyRef ref, const float* pos, float* height) const;
 
 	///// @}
 	///// @name Miscellaneous Functions
@@ -262,36 +262,36 @@ type DtNavMeshQuery struct {
 	///// Returns true if the polygon reference is valid and passes the filter restrictions.
 	/////  @param[in]		ref			The polygon reference to check.
 	/////  @param[in]		filter		The filter to apply.
-	//bool isValidPolyRef(DtPolyRef ref, const dtQueryFilter* filter) const;
+	//bool isValidPolyRef(PolyRef ref, const QueryFilter* filter) const;
 
 	///// Returns true if the polygon reference is in the closed list.
 	/////  @param[in]		ref		The reference id of the polygon to check.
 	///// @returns True if the polygon is in closed list.
-	//bool isInClosedList(DtPolyRef ref) const;
+	//bool isInClosedList(PolyRef ref) const;
 	///// @}
 
-	nav          *NavMesh     // Pointer to navmesh data.
-	query        queryData    // Sliced query state.
-	tinyNodePool *DtNodePool  // Pointer to small node pool.
-	nodePool     *DtNodePool  // Pointer to node pool.
-	openList     *dtNodeQueue // Pointer to open list queue.
+	nav          *NavMesh   // Pointer to navmesh data.
+	query        queryData  // Sliced query state.
+	tinyNodePool *NodePool  // Pointer to small node pool.
+	nodePool     *NodePool  // Pointer to node pool.
+	openList     *nodeQueue // Pointer to open list queue.
 }
 
-type dtQueryData struct {
-	status           DtStatus
-	lastBestNode     *DtNode
+type queryData struct {
+	status           Status
+	lastBestNode     *Node
 	lastBestNodeCost float32
-	startRef, endRef DtPolyRef
+	startRef, endRef PolyRef
 	startPos, endPos d3.Vec3
-	filter           *DtQueryFilter
+	filter           *QueryFilter
 	options          uint32
 	raycastLimitSqr  float32
 }
 
-// NewDtNavMeshQuery initializes the query object.
+// NewNavMeshQuery initializes the query object.
 //
 //  Arguments:
-//   nav       Pointer to the dtNavMesh object to use for all queries.
+//   nav       Pointer to the NavMesh object to use for all queries.
 //   maxNodes  Maximum number of search nodes. [Limits: 0 < value <= 65535]
 //
 // Return the status flags for the initialization of the query object and the
@@ -300,30 +300,30 @@ type dtQueryData struct {
 // Must be the first function called after construction, before other
 // functions are used.
 // This function can be used multiple times.
-func NewDtNavMeshQuery(nav *DtNavMesh, maxNodes int32) (DtStatus, *DtNavMeshQuery) {
-	if maxNodes > int32(dtNullIdx) || maxNodes > int32(1<<dtNodeParentBits)-1 {
-		return DtFailure | DtInvalidParam, nil
+func NewNavMeshQuery(nav *NavMesh, maxNodes int32) (Status, *NavMeshQuery) {
+	if maxNodes > int32(nullIdx) || maxNodes > int32(1<<nodeParentBits)-1 {
+		return Failure | InvalidParam, nil
 	}
 
-	q := &DtNavMeshQuery{}
+	q := &NavMeshQuery{}
 	q.nav = nav
 
 	if q.nodePool == nil || q.nodePool.MaxNodes() < maxNodes {
 		if q.nodePool != nil {
 			q.nodePool = nil
 		}
-		q.nodePool = newDtNodePool(maxNodes, int32(math32.NextPow2(uint32(maxNodes/4))))
+		q.nodePool = newNodePool(maxNodes, int32(math32.NextPow2(uint32(maxNodes/4))))
 		if q.nodePool == nil {
-			return DtFailure | DtOutOfMemory, nil
+			return Failure | OutOfMemory, nil
 		}
 	} else {
 		q.nodePool.Clear()
 	}
 
 	if q.tinyNodePool == nil {
-		q.tinyNodePool = newDtNodePool(64, 32)
+		q.tinyNodePool = newNodePool(64, 32)
 		if q.tinyNodePool == nil {
-			return DtFailure | DtOutOfMemory, nil
+			return Failure | OutOfMemory, nil
 		}
 	} else {
 		q.tinyNodePool.Clear()
@@ -333,15 +333,15 @@ func NewDtNavMeshQuery(nav *DtNavMesh, maxNodes int32) (DtStatus, *DtNavMeshQuer
 		if q.openList != nil {
 			q.openList = nil
 		}
-		q.openList = newDtNodeQueue(maxNodes)
+		q.openList = newnodeQueue(maxNodes)
 		if q.openList == nil {
-			return DtFailure | DtOutOfMemory, nil
+			return Failure | OutOfMemory, nil
 		}
 	} else {
 		q.openList.clear()
 	}
 
-	return DtSuccess, q
+	return Success, q
 }
 
 // FindPath finds a path from the start polygon to the end polygon.
@@ -366,18 +366,18 @@ func NewDtNavMeshQuery(nav *DtNavMesh, maxNodes int32) (DtStatus, *DtNavMeshQuer
 //
 // The start and end positions are used to calculate traversal costs.
 // (The y-values impact the result.)
-func (q *DtNavMeshQuery) FindPath(
-	startRef, endRef DtPolyRef,
+func (q *NavMeshQuery) FindPath(
+	startRef, endRef PolyRef,
 	startPos, endPos d3.Vec3,
-	filter *DtQueryFilter,
-	path *[]DtPolyRef,
+	filter *QueryFilter,
+	path *[]PolyRef,
 	pathCount *int32,
-	maxPath int32) DtStatus {
+	maxPath int32) Status {
 
 	if len(*path) < int(maxPath) {
 		// immediately check the provided slice
 		// is big enough to store maxPath nodes
-		return DtFailure | DtInvalidParam
+		return Failure | InvalidParam
 	}
 
 	if pathCount != nil {
@@ -387,20 +387,20 @@ func (q *DtNavMeshQuery) FindPath(
 	// Validate input
 	if !q.nav.IsValidPolyRef(startRef) || !q.nav.IsValidPolyRef(endRef) ||
 		len(startPos) < 3 || len(endPos) < 3 || filter == nil || maxPath <= 0 || path == nil || pathCount == nil {
-		return DtFailure | DtInvalidParam
+		return Failure | InvalidParam
 	}
 
 	if startRef == endRef {
 		(*path)[0] = startRef
 		*pathCount = 1
-		return DtSuccess
+		return Success
 	}
 
 	q.nodePool.Clear()
 	q.openList.clear()
 
 	var (
-		startNode, lastBestNode *DtNode
+		startNode, lastBestNode *Node
 		lastBestNodeCost        float32
 	)
 	startNode = q.nodePool.Node(startRef, 0)
@@ -409,7 +409,7 @@ func (q *DtNavMeshQuery) FindPath(
 	startNode.Cost = 0
 	startNode.Total = startPos.Dist(endPos) * HScale
 	startNode.ID = startRef
-	startNode.Flags = dtNodeOpen
+	startNode.Flags = nodeOpen
 	q.openList.push(startNode)
 
 	lastBestNode = startNode
@@ -419,12 +419,12 @@ func (q *DtNavMeshQuery) FindPath(
 
 	for !q.openList.empty() {
 
-		var bestNode *DtNode
+		var bestNode *Node
 
 		// Remove node from open list and put it in closed list.
 		bestNode = q.openList.pop()
-		bestNode.Flags &= ^dtNodeOpen
-		bestNode.Flags |= dtNodeClosed
+		bestNode.Flags &= ^nodeOpen
+		bestNode.Flags |= nodeClosed
 
 		// Reached the goal, stop searching.
 		if bestNode.ID == endRef {
@@ -435,9 +435,9 @@ func (q *DtNavMeshQuery) FindPath(
 		// Get current poly and tile.
 		// The API input has been cheked already, skip checking internal data.
 		var (
-			bestRef  DtPolyRef
-			bestTile *DtMeshTile
-			bestPoly *DtPoly
+			bestRef  PolyRef
+			bestTile *MeshTile
+			bestPoly *Poly
 		)
 
 		bestRef = bestNode.ID
@@ -447,9 +447,9 @@ func (q *DtNavMeshQuery) FindPath(
 
 		// Get parent poly and tile.
 		var (
-			parentRef  DtPolyRef
-			parentTile *DtMeshTile
-			parentPoly *DtPoly
+			parentRef  PolyRef
+			parentTile *MeshTile
+			parentPoly *Poly
 		)
 		if bestNode.PIdx != 0 {
 			parentRef = q.nodePool.NodeAtIdx(int32(bestNode.PIdx)).ID
@@ -459,7 +459,7 @@ func (q *DtNavMeshQuery) FindPath(
 		}
 
 		var i uint32
-		for i = bestPoly.FirstLink; i != dtNullLink; i = bestTile.Links[i].Next {
+		for i = bestPoly.FirstLink; i != nullLink; i = bestTile.Links[i].Next {
 			neighbourRef := bestTile.Links[i].Ref
 
 			// Skip invalid ids and do not expand back to where we came from.
@@ -470,8 +470,8 @@ func (q *DtNavMeshQuery) FindPath(
 			// Get neighbour poly and tile.
 			// The API input has been cheked already, skip checking internal data.
 			var (
-				neighbourTile *DtMeshTile
-				neighbourPoly *DtPoly
+				neighbourTile *MeshTile
+				neighbourPoly *Poly
 			)
 			q.nav.TileAndPolyByRefUnsafe(neighbourRef, &neighbourTile, &neighbourPoly)
 
@@ -498,7 +498,7 @@ func (q *DtNavMeshQuery) FindPath(
 				status := q.getEdgeMidPoint(bestRef, bestPoly, bestTile,
 					neighbourRef, neighbourPoly, neighbourTile,
 					neighbourNode.Pos[:])
-				if DtStatusFailed(status) {
+				if StatusFailed(status) {
 					log.Fatalf("getEdgeMidPoint failed")
 				}
 			}
@@ -533,27 +533,27 @@ func (q *DtNavMeshQuery) FindPath(
 			total := cost + heuristic
 
 			// The node is already in open list and the new result is worse, skip.
-			if (neighbourNode.Flags&dtNodeOpen) != 0 && total >= neighbourNode.Total {
+			if (neighbourNode.Flags&nodeOpen) != 0 && total >= neighbourNode.Total {
 				continue
 			}
 			// The node is already visited and process, and the new result is worse, skip.
-			if (neighbourNode.Flags&dtNodeClosed) != 0 && total >= neighbourNode.Total {
+			if (neighbourNode.Flags&nodeClosed) != 0 && total >= neighbourNode.Total {
 				continue
 			}
 
 			// Add or update the node.
 			neighbourNode.PIdx = q.nodePool.NodeIdx(bestNode)
 			neighbourNode.ID = neighbourRef
-			neighbourNode.Flags = (neighbourNode.Flags & DtNodeFlags(^DtNodeFlags(dtNodeClosed)))
+			neighbourNode.Flags = (neighbourNode.Flags & NodeFlags(^NodeFlags(nodeClosed)))
 			neighbourNode.Cost = cost
 			neighbourNode.Total = total
 
-			if (neighbourNode.Flags & dtNodeOpen) != 0 {
+			if (neighbourNode.Flags & nodeOpen) != 0 {
 				// Already in open, update node location.
 				q.openList.modify(neighbourNode)
 			} else {
 				// Put the node in open list.
-				neighbourNode.Flags |= dtNodeOpen
+				neighbourNode.Flags |= nodeOpen
 				q.openList.push(neighbourNode)
 			}
 
@@ -565,35 +565,35 @@ func (q *DtNavMeshQuery) FindPath(
 		}
 	}
 
-	status := q.getPathToNode(lastBestNode, path, pathCount, maxPath)
+	status := q.pathToNode(lastBestNode, path, pathCount, maxPath)
 
 	if lastBestNode.ID != endRef {
-		status |= DtPartialResult
+		status |= PartialResult
 	}
 
 	if outOfNodes {
-		status |= DtOutOfNodes
+		status |= OutOfNodes
 	}
 
 	return status
 }
 
-// Vertex flags returned by DtNavMeshQuery.FindStraightPath.
+// Vertex flags returned by NavMeshQuery.FindStraightPath.
 const (
 	// The vertex is the start position in the path.
-	DtStraightPathStart uint8 = 0x01
+	StraightPathStart uint8 = 0x01
 	// The vertex is the end position in the path.
-	DtStraightPathEnd uint8 = 0x02
+	StraightPathEnd uint8 = 0x02
 	// The vertex is the start of an off-mesh connection.
-	DtStraightPathOffMeshConnection uint8 = 0x04
+	StraightPathOffMeshConnection uint8 = 0x04
 )
 
-// Options for DtNavMeshQuery.FindStraightPath.
+// Options for NavMeshQuery.FindStraightPath.
 const (
 	// Add a vertex at every polygon edge crossing where area changes.
-	DtStraightPathAreaCrossings uint8 = 0x01
+	StraightPathAreaCrossings uint8 = 0x01
 	// Add a vertex at every polygon edge crossing.
-	DtStraightPathAllCrossings uint8 = 0x02
+	StraightPathAllCrossings uint8 = 0x02
 )
 
 // FindStraightPath finds the straight path from the start to the end position
@@ -608,60 +608,60 @@ const (
 //   [out] straightPath      Points describing the straight path
 //                           [Length: == straightPathCount].
 //   [out] straightPathFlags Flags describing each point.
-//                           (See: dtStraightPathFlags)
+//                           (See: StraightPathFlags)
 //   [out] straightPathRefs  The reference id of the polygon that is being
 //                           entered at each point.
 //   [in]  maxStraightPath   The maximum number of points the straight path
 //                           arrays can hold.  [Limit: > 0]
-//   [in]  options           Query options. (see: dtStraightPathOptions)
+//   [in]  options           Query options. (see: StraightPathOptions)
 //
 // Returns The status flags for the query and the number of point in the
 // straight path.
 //
 // The straightPath, straightPathFlags and straightPathRefs slices must already
 // be allocated and contain at least maxStraightPath elements.
-func (q *DtNavMeshQuery) FindStraightPath(
+func (q *NavMeshQuery) FindStraightPath(
 	startPos, endPos d3.Vec3,
-	path []DtPolyRef, pathSize int32,
+	path []PolyRef, pathSize int32,
 	straightPath []d3.Vec3,
 	straightPathFlags []uint8,
-	straightPathRefs []DtPolyRef,
+	straightPathRefs []PolyRef,
 	maxStraightPath int32,
-	options int32) (DtStatus, int32) {
+	options int32) (Status, int32) {
 
 	assert.True(q.nav != nil, "NavMesh should not be nil")
 
 	if maxStraightPath == 0 {
 		fmt.Println("maxStraightPath == 0")
-		return DtFailure | DtInvalidParam, 0
+		return Failure | InvalidParam, 0
 	}
 
 	if len(path) == 0 {
 		fmt.Println("len(path) == 0")
-		return DtFailure | DtInvalidParam, 0
+		return Failure | InvalidParam, 0
 	}
 
 	var (
-		stat  DtStatus
+		stat  Status
 		count int32
 	)
 
 	// TODO: Should this be callers responsibility?
 	closestStartPos := d3.NewVec3()
-	if DtStatusFailed(q.closestPointOnPolyBoundary(path[0], startPos, closestStartPos)) {
-		return DtFailure | DtInvalidParam, 0
+	if StatusFailed(q.closestPointOnPolyBoundary(path[0], startPos, closestStartPos)) {
+		return Failure | InvalidParam, 0
 	}
 
 	closestEndPos := d3.NewVec3()
-	if DtStatusFailed(q.closestPointOnPolyBoundary(path[pathSize-1], endPos, closestEndPos)) {
-		return DtFailure | DtInvalidParam, 0
+	if StatusFailed(q.closestPointOnPolyBoundary(path[pathSize-1], endPos, closestEndPos)) {
+		return Failure | InvalidParam, 0
 	}
 
 	// Add start point.
-	stat = q.appendVertex(closestStartPos, DtStraightPathStart, path[0],
+	stat = q.appendVertex(closestStartPos, StraightPathStart, path[0],
 		straightPath, straightPathFlags, straightPathRefs,
 		&count, maxStraightPath)
-	if stat != DtInProgress {
+	if stat != InProgress {
 		return stat, count
 	}
 
@@ -689,16 +689,16 @@ func (q *DtNavMeshQuery) FindStraightPath(
 				var fromType uint8 // fromType is ignored.
 
 				// Next portal.
-				if DtStatusFailed(q.getPortalPoints6(path[i], path[i+1], left, right, &fromType, &toType)) {
+				if StatusFailed(q.getPortalPoints6(path[i], path[i+1], left, right, &fromType, &toType)) {
 					// Failed to get portal points, in practice this means that path[i+1] is invalid polygon.
 					// Clamp the end point to path[i], and return the path so far.
-					if DtStatusFailed(q.closestPointOnPolyBoundary(path[i], endPos, closestEndPos)) {
+					if StatusFailed(q.closestPointOnPolyBoundary(path[i], endPos, closestEndPos)) {
 						// This should only happen when the first polygon is invalid.
-						return DtFailure | DtInvalidParam, 0
+						return Failure | InvalidParam, 0
 					}
 
 					// Apeend portals along the current straight path segment.
-					if (options & int32(DtStraightPathAreaCrossings|DtStraightPathAllCrossings)) != 0 {
+					if (options & int32(StraightPathAreaCrossings|StraightPathAllCrossings)) != 0 {
 						// Ignore status return value as we're just about to return anyway.
 						q.appendPortals(apexIndex, i, closestEndPos, path,
 							straightPath, straightPathFlags, straightPathRefs,
@@ -710,9 +710,9 @@ func (q *DtNavMeshQuery) FindStraightPath(
 						straightPath, straightPathFlags, straightPathRefs,
 						&count, maxStraightPath)
 
-					stat = DtSuccess | DtPartialResult
+					stat = Success | PartialResult
 					if count >= maxStraightPath {
-						stat |= DtBufferTooSmall
+						stat |= BufferTooSmall
 					}
 					return stat, count
 				}
@@ -728,7 +728,7 @@ func (q *DtNavMeshQuery) FindStraightPath(
 				// End of the path.
 				left.Assign(closestEndPos)
 				right.Assign(closestEndPos)
-				toType = uint8(dtPolyTypeGround)
+				toType = uint8(polyTypeGround)
 			}
 
 			// Right vertex.
@@ -744,11 +744,11 @@ func (q *DtNavMeshQuery) FindStraightPath(
 					rightIndex = i
 				} else {
 					// Append portals along the current straight path segment.
-					if (options & int32(DtStraightPathAreaCrossings|DtStraightPathAllCrossings)) != 0 {
+					if (options & int32(StraightPathAreaCrossings|StraightPathAllCrossings)) != 0 {
 						stat = q.appendPortals(apexIndex, leftIndex, portalLeft, path,
 							straightPath, straightPathFlags, straightPathRefs,
 							&count, maxStraightPath, options)
-						if stat != DtInProgress {
+						if stat != InProgress {
 							return stat, count
 						}
 					}
@@ -758,9 +758,9 @@ func (q *DtNavMeshQuery) FindStraightPath(
 
 					var flags uint8
 					if leftPolyRef == 0 {
-						flags = DtStraightPathEnd
-					} else if leftPolyType == dtPolyTypeOffMeshConnection {
-						flags = DtStraightPathOffMeshConnection
+						flags = StraightPathEnd
+					} else if leftPolyType == polyTypeOffMeshConnection {
+						flags = StraightPathOffMeshConnection
 					}
 					ref := leftPolyRef
 
@@ -768,7 +768,7 @@ func (q *DtNavMeshQuery) FindStraightPath(
 					stat = q.appendVertex(portalApex, flags, ref,
 						straightPath, straightPathFlags, straightPathRefs,
 						&count, maxStraightPath)
-					if stat != DtInProgress {
+					if stat != InProgress {
 						return stat, count
 					}
 
@@ -797,11 +797,11 @@ func (q *DtNavMeshQuery) FindStraightPath(
 					leftIndex = i
 				} else {
 					// Append portals along the current straight path segment.
-					if (options & int32(DtStraightPathAreaCrossings|DtStraightPathAllCrossings)) != 0 {
+					if (options & int32(StraightPathAreaCrossings|StraightPathAllCrossings)) != 0 {
 						stat = q.appendPortals(apexIndex, rightIndex, portalRight, path,
 							straightPath, straightPathFlags, straightPathRefs,
 							&count, maxStraightPath, options)
-						if stat != DtInProgress {
+						if stat != InProgress {
 							return stat, count
 						}
 					}
@@ -811,9 +811,9 @@ func (q *DtNavMeshQuery) FindStraightPath(
 
 					var flags uint8
 					if rightPolyRef == 0 {
-						flags = DtStraightPathEnd
-					} else if rightPolyType == dtPolyTypeOffMeshConnection {
-						flags = DtStraightPathOffMeshConnection
+						flags = StraightPathEnd
+					} else if rightPolyType == polyTypeOffMeshConnection {
+						flags = StraightPathOffMeshConnection
 					}
 					ref := rightPolyRef
 
@@ -821,7 +821,7 @@ func (q *DtNavMeshQuery) FindStraightPath(
 					stat = q.appendVertex(portalApex, flags, ref,
 						straightPath, straightPathFlags, straightPathRefs,
 						&count, maxStraightPath)
-					if stat != DtInProgress {
+					if stat != InProgress {
 						return stat, count
 					}
 
@@ -839,71 +839,71 @@ func (q *DtNavMeshQuery) FindStraightPath(
 		}
 
 		// Append portals along the current straight path segment.
-		if (options & int32(DtStraightPathAreaCrossings|DtStraightPathAllCrossings)) != 0 {
+		if (options & int32(StraightPathAreaCrossings|StraightPathAllCrossings)) != 0 {
 			stat = q.appendPortals(apexIndex, pathSize-1, closestEndPos, path,
 				straightPath, straightPathFlags, straightPathRefs,
 				&count, maxStraightPath, options)
-			if stat != DtInProgress {
+			if stat != InProgress {
 				return stat, count
 			}
 		}
 	}
 
 	// Ignore status return value as we're just about to return anyway.
-	q.appendVertex(closestEndPos, DtStraightPathEnd, 0,
+	q.appendVertex(closestEndPos, StraightPathEnd, 0,
 		straightPath, straightPathFlags, straightPathRefs,
 		&count, maxStraightPath)
 
-	stat = DtSuccess
+	stat = Success
 	if count >= maxStraightPath {
-		stat |= DtBufferTooSmall
+		stat |= BufferTooSmall
 	}
 	return stat, count
 }
 
 // appendPortals appends intermediate portal points to a straight path.
-func (q *DtNavMeshQuery) appendPortals(
+func (q *NavMeshQuery) appendPortals(
 	startIdx, endIdx int32,
 	endPos d3.Vec3,
-	path []DtPolyRef,
+	path []PolyRef,
 	straightPath []d3.Vec3,
 	straightPathFlags []uint8,
-	straightPathRefs []DtPolyRef,
+	straightPathRefs []PolyRef,
 	straightPathCount *int32,
 	maxStraightPath,
-	options int32) DtStatus {
+	options int32) Status {
 
 	startPos := straightPath[*straightPathCount-1]
 	// Append or update last vertex
-	var stat DtStatus
+	var stat Status
 	for i := startIdx; i < endIdx; i++ {
 		// Calculate portal
 		from := path[i]
 		var (
-			fromTile *DtMeshTile
-			fromPoly *DtPoly
+			fromTile *MeshTile
+			fromPoly *Poly
 		)
-		if DtStatusFailed(q.nav.TileAndPolyByRef(from, &fromTile, &fromPoly)) {
-			return DtFailure | DtInvalidParam
+		if StatusFailed(q.nav.TileAndPolyByRef(from, &fromTile, &fromPoly)) {
+			return Failure | InvalidParam
 		}
 
 		to := path[i+1]
 		var (
-			toTile *DtMeshTile
-			toPoly *DtPoly
+			toTile *MeshTile
+			toPoly *Poly
 		)
-		if DtStatusFailed(q.nav.TileAndPolyByRef(to, &toTile, &toPoly)) {
+		if StatusFailed(q.nav.TileAndPolyByRef(to, &toTile, &toPoly)) {
 
-			return DtFailure | DtInvalidParam
+			return Failure | InvalidParam
 		}
 
 		left := d3.NewVec3()
 		right := d3.NewVec3()
-		if DtStatusFailed(q.getPortalPoints8(from, fromPoly, fromTile, to, toPoly, toTile, left, right)) {
+		if StatusFailed(q.getPortalPoints8(from, fromPoly, fromTile, to, toPoly, toTile, left, right)) {
 			break
 		}
 
-		if (options & int32(DtStraightPathAreaCrossings)) != 0 {
+		if (options & int32(StraightPathAreaCrossings)) != 0 {
 			// Skip intersection if only area crossings are requested.
 			if fromPoly.Area() == toPoly.Area() {
 				continue
@@ -918,24 +918,24 @@ func (q *DtNavMeshQuery) appendPortals(
 			stat = q.appendVertex(pt, 0, path[i+1],
 				straightPath, straightPathFlags, straightPathRefs,
 				straightPathCount, maxStraightPath)
-			if stat != DtInProgress {
+			if stat != InProgress {
 				return stat
 			}
 		}
 	}
-	return DtInProgress
+	return InProgress
 }
 
 // appendVertex appends a vertex to a straight path.
-func (q *DtNavMeshQuery) appendVertex(
+func (q *NavMeshQuery) appendVertex(
 	pos d3.Vec3,
 	flags uint8,
-	ref DtPolyRef,
+	ref PolyRef,
 	straightPath []d3.Vec3,
 	straightPathFlags []uint8,
-	straightPathRefs []DtPolyRef,
+	straightPathRefs []PolyRef,
 	straightPathCount *int32,
-	maxStraightPath int32) DtStatus {
+	maxStraightPath int32) Status {
 
 	if (*straightPathCount) > 0 && pos.Approx(straightPath[*straightPathCount-1]) {
 		// The vertices are equal, update flags and poly.
@@ -958,58 +958,58 @@ func (q *DtNavMeshQuery) appendVertex(
 
 		// If there is no space to append more vertices, return.
 		if (*straightPathCount) >= maxStraightPath {
-			return DtSuccess | DtBufferTooSmall
+			return Success | BufferTooSmall
 		}
 
 		// If reached end of path, return.
-		if flags == DtStraightPathEnd {
-			return DtSuccess
+		if flags == StraightPathEnd {
+			return Success
 		}
 	}
-	return DtInProgress
+	return InProgress
 }
 
 // getEdgeMidPoint returns the edge mid point between two polygons.
-func (q *DtNavMeshQuery) getEdgeMidPoint(
-	from DtPolyRef, fromPoly *DtPoly, fromTile *DtMeshTile,
-	to DtPolyRef, toPoly *DtPoly, toTile *DtMeshTile,
-	mid []float32) DtStatus {
+func (q *NavMeshQuery) getEdgeMidPoint(
+	from PolyRef, fromPoly *Poly, fromTile *MeshTile,
+	to PolyRef, toPoly *Poly, toTile *MeshTile,
+	mid []float32) Status {
 
 	left := make([]float32, 3)
 	right := make([]float32, 3)
 
-	if DtStatusFailed(q.getPortalPoints8(from, fromPoly, fromTile, to, toPoly, toTile, left, right)) {
-		return DtFailure | DtInvalidParam
+	if StatusFailed(q.getPortalPoints8(from, fromPoly, fromTile, to, toPoly, toTile, left, right)) {
+		return Failure | InvalidParam
 	}
 	mid[0] = (left[0] + right[0]) * 0.5
 	mid[1] = (left[1] + right[1]) * 0.5
 	mid[2] = (left[2] + right[2]) * 0.5
-	return DtSuccess
+	return Success
 }
 
 // getPortalPoints6 returns portal points between two polygons.
-func (q *DtNavMeshQuery) getPortalPoints6(
-	from, to DtPolyRef,
+func (q *NavMeshQuery) getPortalPoints6(
+	from, to PolyRef,
 	left, right d3.Vec3,
-	fromType, toType *uint8) DtStatus {
+	fromType, toType *uint8) Status {
 
 	assert.True(q.nav != nil, "NavMesh should not be nil")
 
 	var (
-		fromTile *DtMeshTile
-		fromPoly *DtPoly
+		fromTile *MeshTile
+		fromPoly *Poly
 	)
-	if DtStatusFailed(q.nav.TileAndPolyByRef(from, &fromTile, &fromPoly)) {
-		return DtFailure | DtInvalidParam
+	if StatusFailed(q.nav.TileAndPolyByRef(from, &fromTile, &fromPoly)) {
+		return Failure | InvalidParam
 	}
 	*fromType = fromPoly.Type()
 
 	var (
-		toTile *DtMeshTile
-		toPoly *DtPoly
+		toTile *MeshTile
+		toPoly *Poly
 	)
-	if DtStatusFailed(q.nav.TileAndPolyByRef(to, &toTile, &toPoly)) {
-		return DtFailure | DtInvalidParam
+	if StatusFailed(q.nav.TileAndPolyByRef(to, &toTile, &toPoly)) {
+		return Failure | InvalidParam
 	}
 	*toType = toPoly.Type()
 
@@ -1017,51 +1017,51 @@ func (q *DtNavMeshQuery) getPortalPoints6(
 }
 
 // getPortalPoints8 returns portal points between two polygons.
-func (q *DtNavMeshQuery) getPortalPoints8(
-	from DtPolyRef, fromPoly *DtPoly, fromTile *DtMeshTile,
-	to DtPolyRef, toPoly *DtPoly, toTile *DtMeshTile,
-	left, right d3.Vec3) DtStatus {
+func (q *NavMeshQuery) getPortalPoints8(
+	from PolyRef, fromPoly *Poly, fromTile *MeshTile,
+	to PolyRef, toPoly *Poly, toTile *MeshTile,
+	left, right d3.Vec3) Status {
 
 	// Find the link that points to the 'to' polygon.
-	var link *dtLink
-	for i := fromPoly.FirstLink; i != dtNullLink; i = fromTile.Links[i].Next {
+	var link *link
+	for i := fromPoly.FirstLink; i != nullLink; i = fromTile.Links[i].Next {
 		if fromTile.Links[i].Ref == to {
 			link = &fromTile.Links[i]
 			break
 		}
 	}
 	if link == nil {
-		return DtFailure | DtInvalidParam
+		return Failure | InvalidParam
 	}
 
 	// Handle off-mesh connections.
-	if fromPoly.Type() == dtPolyTypeOffMeshConnection {
+	if fromPoly.Type() == polyTypeOffMeshConnection {
 		// Find link that points to first vertex.
-		for i := fromPoly.FirstLink; i != dtNullLink; i = fromTile.Links[i].Next {
+		for i := fromPoly.FirstLink; i != nullLink; i = fromTile.Links[i].Next {
 			if fromTile.Links[i].Ref == to {
 				// TODO: AR, repass here and test
 				v := fromTile.Links[i].Edge
 				vidx := fromPoly.Verts[v] * 3
 				copy(left, fromTile.Verts[vidx:vidx+3])
 				copy(right, fromTile.Verts[vidx:vidx+3])
-				return DtSuccess
+				return Success
 			}
 		}
-		return DtFailure | DtInvalidParam
+		return Failure | InvalidParam
 	}
 
-	if toPoly.Type() == dtPolyTypeOffMeshConnection {
-		for i := toPoly.FirstLink; i != dtNullLink; i = toTile.Links[i].Next {
+	if toPoly.Type() == polyTypeOffMeshConnection {
+		for i := toPoly.FirstLink; i != nullLink; i = toTile.Links[i].Next {
 			if toTile.Links[i].Ref == from {
 				// TODO: AR, repass here and test
 				v := toTile.Links[i].Edge
 				vidx := fromPoly.Verts[v] * 3
 				copy(left, toTile.Verts[vidx:vidx+3])
 				copy(right, toTile.Verts[vidx:vidx+3])
-				return DtSuccess
+				return Success
 			}
 		}
-		return DtFailure | DtInvalidParam
+		return Failure | InvalidParam
 	}
 
 	// Find portal vertices.
@@ -1074,7 +1074,7 @@ func (q *DtNavMeshQuery) getPortalPoints8(
 	v1idx := v1 * 3
 	copy(right, fromTile.Verts[v1idx:v1idx+3])
 
-	// If the link is at tile boundary, dtClamp the vertices to
+	// If the link is at tile boundary, clamp the vertices to
 	// the link width.
 	if link.Side != 0xff {
 		// Unpack portal limits.
@@ -1087,18 +1087,18 @@ func (q *DtNavMeshQuery) getPortalPoints8(
 		}
 	}
 
-	return DtSuccess
+	return Success
 }
 
-// getPathToNode gets the path leading to the specified end node.
-func (q *DtNavMeshQuery) getPathToNode(
-	endNode *DtNode,
-	path *[]DtPolyRef,
+// pathToNode gets the path leading to the specified end node.
+func (q *NavMeshQuery) pathToNode(
+	endNode *Node,
+	path *[]PolyRef,
 	pathCount *int32,
-	maxPath int32) DtStatus {
+	maxPath int32) Status {
 
 	var (
-		curNode *DtNode
+		curNode *Node
 		length  int32
 	)
 	// Find the length of the entire path.
@@ -1134,10 +1134,10 @@ func (q *DtNavMeshQuery) getPathToNode(
 	*pathCount = math32.MinInt32(length, maxPath)
 
 	if length > maxPath {
-		return DtSuccess | DtBufferTooSmall
+		return Success | BufferTooSmall
 	}
 
-	return DtSuccess
+	return Success
 }
 
 // closestPointOnPoly uses the detail polygons to find the surface height.
@@ -1145,22 +1145,22 @@ func (q *DtNavMeshQuery) getPathToNode(
 //
 // pos does not have to be within the bounds of the polygon or navigation mesh.
 // See closestPointOnPolyBoundary() for a limited but faster option.
-func (q *DtNavMeshQuery) closestPointOnPoly(ref DtPolyRef, pos, closest d3.Vec3, posOverPoly *bool) DtStatus {
+func (q *NavMeshQuery) closestPointOnPoly(ref PolyRef, pos, closest d3.Vec3, posOverPoly *bool) Status {
 	assert.True(q.nav != nil, "NavMesh should not be nil")
 	var (
-		tile *DtMeshTile
-		poly *DtPoly
+		tile *MeshTile
+		poly *Poly
 	)
 
-	if DtStatusFailed(q.nav.TileAndPolyByRef(ref, &tile, &poly)) {
-		return DtFailure | DtInvalidParam
+	if StatusFailed(q.nav.TileAndPolyByRef(ref, &tile, &poly)) {
+		return Failure | InvalidParam
 	}
 	if tile == nil {
-		return DtFailure | DtInvalidParam
+		return Failure | InvalidParam
 	}
 
 	// Off-mesh connections don't have detail polygons.
-	if poly.Type() == dtPolyTypeOffMeshConnection {
+	if poly.Type() == polyTypeOffMeshConnection {
 		var (
 			v0, v1    d3.Vec3
 			d0, d1, u float32
@@ -1176,7 +1176,7 @@ func (q *DtNavMeshQuery) closestPointOnPoly(ref DtPolyRef, pos, closest d3.Vec3,
 		if posOverPoly != nil {
 			*posOverPoly = false
 		}
-		return DtSuccess
+		return Success
 	}
 
 	e := uintptr(unsafe.Pointer(poly)) - uintptr(unsafe.Pointer(&tile.Polys[0]))
@@ -1187,9 +1187,9 @@ func (q *DtNavMeshQuery) closestPointOnPoly(ref DtPolyRef, pos, closest d3.Vec3,
 	pd := &tile.DetailMeshes[ip]
 
 	// Clamp point to be inside the polygon.
-	verts := make([]float32, dtVertsPerPolygon*3)
-	edged := make([]float32, dtVertsPerPolygon)
-	edget := make([]float32, dtVertsPerPolygon)
+	verts := make([]float32, vertsPerPolygon*3)
+	edged := make([]float32, vertsPerPolygon)
+	edget := make([]float32, vertsPerPolygon)
 	nv := poly.VertCount
 	var i uint8
 	for i = 0; i < nv; i++ {
@@ -1201,7 +1201,7 @@ func (q *DtNavMeshQuery) closestPointOnPoly(ref DtPolyRef, pos, closest d3.Vec3,
 
 	closest.Assign(pos)
 	if !distancePtPolyEdgesSqr(pos, verts, int32(nv), edged, edget) {
-		// Point is outside the polygon, dtClamp to nearest edge.
+		// Point is outside the polygon, clamp to nearest edge.
 		dmin := edged[0]
 		var imin uint8
 		for i = 1; i < nv; i++ {
@@ -1248,7 +1248,7 @@ func (q *DtNavMeshQuery) closestPointOnPoly(ref DtPolyRef, pos, closest d3.Vec3,
 			break
 		}
 	}
-	return DtSuccess
+	return Success
 }
 
 // closestPointOnPolyBoundary uses the detail polygons to find the surface
@@ -1259,22 +1259,22 @@ func (q *DtNavMeshQuery) closestPointOnPoly(ref DtPolyRef, pos, closest d3.Vec3,
 // polygon boundary. The height detail is not used. pos does not have to be
 // within the bounds of the polybon or the navigation
 // mesh.
-func (q *DtNavMeshQuery) closestPointOnPolyBoundary(ref DtPolyRef, pos, closest d3.Vec3) DtStatus {
+func (q *NavMeshQuery) closestPointOnPolyBoundary(ref PolyRef, pos, closest d3.Vec3) Status {
 	assert.True(q.nav != nil, "NavMesh should not be nil")
 
 	var (
-		tile *DtMeshTile
-		poly *DtPoly
+		tile *MeshTile
+		poly *Poly
 	)
-	if DtStatusFailed(q.nav.TileAndPolyByRef(ref, &tile, &poly)) {
-		return DtFailure | DtInvalidParam
+	if StatusFailed(q.nav.TileAndPolyByRef(ref, &tile, &poly)) {
+		return Failure | InvalidParam
 	}
 
 	// Collect vertices.
 	var (
-		verts [dtVertsPerPolygon * 3]float32
-		edged [dtVertsPerPolygon]float32
-		edget [dtVertsPerPolygon]float32
+		verts [vertsPerPolygon * 3]float32
+		edged [vertsPerPolygon]float32
+		edget [vertsPerPolygon]float32
 		nv    int32
 	)
 	for i := uint8(0); i < poly.VertCount; i++ {
@@ -1287,7 +1287,7 @@ func (q *DtNavMeshQuery) closestPointOnPolyBoundary(ref DtPolyRef, pos, closest 
 		// Point is inside the polygon, return the point.
 		closest.Assign(pos)
 	} else {
-		// Point is outside the polygon, dtClamp to nearest edge.
+		// Point is outside the polygon, clamp to nearest edge.
 		dmin := edged[0]
 		imin := int32(0)
 		for i := int32(1); i < nv; i++ {
@@ -1302,7 +1302,7 @@ func (q *DtNavMeshQuery) closestPointOnPolyBoundary(ref DtPolyRef, pos, closest 
 		d3.Vec3Lerp(closest, va, vb, edget[imin])
 	}
 
-	return DtSuccess
+	return Success
 }
 
 // FindNearestPoly finds the polygon nearest to the specified center point.
@@ -1319,15 +1319,15 @@ func (q *DtNavMeshQuery) closestPointOnPolyBoundary(ref DtPolyRef, pos, closest 
 //   pt       The nearest point on the polygon. [(x, y, z)]
 //
 // Note: If the search box does not intersect any polygons st will be
-// DT_SUCCESS, but ref will be zero. So if in doubt, check ref before using pt.
-func (q *DtNavMeshQuery) FindNearestPoly(center, extents d3.Vec3,
-	filter *DtQueryFilter) (st DtStatus, ref DtPolyRef, pt d3.Vec3) {
+// Success, but ref will be zero. So if in doubt, check ref before using pt.
+func (q *NavMeshQuery) FindNearestPoly(center, extents d3.Vec3,
+	filter *QueryFilter) (st Status, ref PolyRef, pt d3.Vec3) {
 
 	assert.True(q.nav != nil, "Nav should not be nil")
 
-	query := newDtFindNearestPolyQuery(q, center)
+	query := newFindNearestPolyQuery(q, center)
 	st = q.queryPolygons4(center, extents, filter, query)
-	if DtStatusFailed(st) {
+	if StatusFailed(st) {
 		return
 	}
 
@@ -1336,7 +1336,7 @@ func (q *DtNavMeshQuery) FindNearestPoly(center, extents d3.Vec3,
 	if ref = query.nearestRef; ref != 0 {
 		pt = d3.NewVec3From(query.nearestPoint)
 	}
-	st = DtSuccess
+	st = Success
 	return
 }
 
@@ -1353,34 +1353,34 @@ func (q *DtNavMeshQuery) FindNearestPoly(center, extents d3.Vec3,
 //  Return values:
 //   The status flags for the query.
 //
-// If no polygons are found, the function will return DT_SUCCESS with a
+// If no polygons are found, the function will return Success with a
 // polyCount of zero.
 // If polys is too small to hold the entire result set, then the array will be
 // filled to capacity. The method of choosing which polygons from the full set
 // are included in the partial result set is undefined.
-func (q *DtNavMeshQuery) queryPolygons6(
+func (q *NavMeshQuery) queryPolygons6(
 	center, extents []float32,
-	filter *DtQueryFilter,
-	polys []DtPolyRef,
+	filter *QueryFilter,
+	polys []PolyRef,
 	polyCount *int32,
-	maxPolys int32) DtStatus {
+	maxPolys int32) Status {
 
 	if polys == nil || polyCount == nil || maxPolys < 0 {
-		return DtFailure | DtInvalidParam
+		return Failure | InvalidParam
 	}
 
-	collector := newDtCollectPolysQuery(polys, maxPolys)
+	collector := newCollectPolysQuery(polys, maxPolys)
 
 	status := q.queryPolygons4(center, extents, filter, collector)
-	if DtStatusFailed(status) {
+	if StatusFailed(status) {
 		return status
 	}
 
 	*polyCount = collector.numCollected
 	if collector.overflow {
-		return DtSuccess | DtBufferTooSmall
+		return Success | BufferTooSmall
 	}
-	return DtSuccess
+	return Success
 }
 
 // queryPolygons4 finds polygons that overlap the search box.
@@ -1394,17 +1394,17 @@ func (q *DtNavMeshQuery) queryPolygons6(
 //
 // The query will be invoked with batches of polygons. Polygons passed to the
 // query have bounding boxes that overlap with the center and extents passed to
-// this function. The DtPolyQuery.process function is invoked multiple times
+// this function. The polyQuery.process function is invoked multiple times
 // until all overlapping polygons have been processed.
-func (q *DtNavMeshQuery) queryPolygons4(
+func (q *NavMeshQuery) queryPolygons4(
 	center, extents d3.Vec3,
-	filter *DtQueryFilter,
-	query dtPolyQuery) DtStatus {
+	filter *QueryFilter,
+	query polyQuery) Status {
 
 	assert.True(q.nav != nil, "navmesh should not be nill")
 
 	if len(center) != 3 || len(extents) != 3 || filter == nil || query == nil {
-		return DtFailure | DtInvalidParam
+		return Failure | InvalidParam
 	}
 
 	bmin := center.Sub(extents)
@@ -1415,7 +1415,7 @@ func (q *DtNavMeshQuery) queryPolygons4(
 	maxx, maxy := q.nav.CalcTileLoc(bmax)
 
 	const maxNeis int32 = 32
-	neis := make([]*DtMeshTile, maxNeis)
+	neis := make([]*MeshTile, maxNeis)
 
 	for y := miny; y <= maxy; y++ {
 		for x := minx; x <= maxx; x++ {
@@ -1425,27 +1425,27 @@ func (q *DtNavMeshQuery) queryPolygons4(
 			}
 		}
 	}
-	return DtSuccess
+	return Success
 }
 
 // queryPolygonsInTile queries polygons within a tile.
-func (q *DtNavMeshQuery) queryPolygonsInTile(
-	tile *DtMeshTile,
+func (q *NavMeshQuery) queryPolygonsInTile(
+	tile *MeshTile,
 	qmin, qmax []float32,
-	filter *DtQueryFilter,
-	query dtPolyQuery) {
+	filter *QueryFilter,
+	query polyQuery) {
 
 	assert.True(q.nav != nil, "navmesh should not be nill")
 	batchSize := int32(32)
 
-	polyRefs := make([]DtPolyRef, batchSize)
-	polys := make([]*DtPoly, batchSize)
+	polyRefs := make([]PolyRef, batchSize)
+	polys := make([]*Poly, batchSize)
 	var n int32
 
 	if len(tile.BvTree) > 0 {
 
 		var (
-			node            *dtBVNode
+			node            *bvNode
 			nodeIdx, endIdx int32
 			tbmin, tbmax    d3.Vec3
 			qfac            float32
@@ -1485,7 +1485,7 @@ func (q *DtNavMeshQuery) queryPolygonsInTile(
 			isLeafNode := node.I >= 0
 
 			if isLeafNode && overlap {
-				ref := base | DtPolyRef(node.I)
+				ref := base | PolyRef(node.I)
 				if filter.passFilter(ref, tile, &tile.Polys[node.I]) {
 					polyRefs[n] = ref
 					polys[n] = &tile.Polys[node.I]
@@ -1514,11 +1514,11 @@ func (q *DtNavMeshQuery) queryPolygonsInTile(
 		for i := int32(0); i < tile.Header.PolyCount; i++ {
 			p := &tile.Polys[i]
 			// Do not return off-mesh connection polygons.
-			if p.Type() == dtPolyTypeOffMeshConnection {
+			if p.Type() == polyTypeOffMeshConnection {
 				continue
 			}
 			// Must pass filter
-			ref := base | DtPolyRef(i)
+			ref := base | PolyRef(i)
 			if !filter.passFilter(ref, tile, p) {
 				continue
 			}
@@ -1554,11 +1554,11 @@ func (q *DtNavMeshQuery) queryPolygonsInTile(
 }
 
 // NodePool returns the node pool.
-func (q *DtNavMeshQuery) NodePool() *DtNodePool {
+func (q *NavMeshQuery) NodePool() *NodePool {
 	return q.nodePool
 }
 
 // AttachedNavMesh returns the navigation mesh the query object is using.
-func (q *DtNavMeshQuery) AttachedNavMesh() *DtNavMesh {
+func (q *NavMeshQuery) AttachedNavMesh() *NavMesh {
 	return q.nav
 }

--- a/queryfilter.go
+++ b/queryfilter.go
@@ -2,7 +2,7 @@ package detour
 
 import "github.com/aurelien-rainone/gogeo/f32/d3"
 
-// DtQueryFilter defines polygon filtering and traversal costs for navigation
+// QueryFilter defines polygon filtering and traversal costs for navigation
 // mesh query operations.
 //
 //  The Default Implementation
@@ -36,12 +36,12 @@ import "github.com/aurelien-rainone/gogeo/f32/d3"
 //     proportional to the travel distance. Implementing a cost modifier less
 //     than 1.0 is likely to lead to problems during pathfinding.
 //
-// see dtNavMeshQuery
-type DtQueryFilter struct {
+// see NavMeshQuery
+type QueryFilter struct {
 	// TODO: should be an interface
 	// Cost per area type.
 	// (Used by default implementation.)
-	areaCost [dtMaxAreas]float32
+	areaCost [maxAreas]float32
 
 	// Flags for polygons that can be visited.
 	// (Used by default implementation.)
@@ -52,41 +52,41 @@ type DtQueryFilter struct {
 	excludeFlags uint16
 }
 
-// NewDtQueryFilter initializes a new query filter.
-func NewDtQueryFilter() *DtQueryFilter {
-	qf := DtQueryFilter{
+// NewQueryFilter initializes a new query filter.
+func NewQueryFilter() *QueryFilter {
+	qf := QueryFilter{
 		includeFlags: 0xffff,
 		excludeFlags: 0,
 	}
-	for i := int32(0); i < dtMaxAreas; i++ {
+	for i := int32(0); i < maxAreas; i++ {
 		qf.areaCost[i] = 1.0
 	}
 	return &qf
 }
 
 // AreaCost returns the traversal cost of the area which id is i.
-func (qf *DtQueryFilter) AreaCost(i int32) float32 { return qf.areaCost[i] }
+func (qf *QueryFilter) AreaCost(i int32) float32 { return qf.areaCost[i] }
 
 // SetAreaCost sets the traversal cost of the area which id is i.
-func (qf *DtQueryFilter) SetAreaCost(i int32, cost float32) { qf.areaCost[i] = cost }
+func (qf *QueryFilter) SetAreaCost(i int32, cost float32) { qf.areaCost[i] = cost }
 
 // IncludeFlags returns the include flags for the filter.
 //
 // Any polygons that include one or more of these flags will be
 // included in the operation.
-func (qf *DtQueryFilter) IncludeFlags() uint16 { return qf.includeFlags }
+func (qf *QueryFilter) IncludeFlags() uint16 { return qf.includeFlags }
 
 // SetIncludeFlags sets the include flags for the filter.
-func (qf *DtQueryFilter) SetIncludeFlags(flags uint16) { qf.includeFlags = flags }
+func (qf *QueryFilter) SetIncludeFlags(flags uint16) { qf.includeFlags = flags }
 
 // ExcludeFlags returns the exclude flags for the filter.
 //
 // Any polygons that include one ore more of these flags will be
 // excluded from the operation.
-func (qf *DtQueryFilter) ExcludeFlags() uint16 { return qf.excludeFlags }
+func (qf *QueryFilter) ExcludeFlags() uint16 { return qf.excludeFlags }
 
 // SetExcludeFlags sets the exclude flags for the filter.
-func (qf *DtQueryFilter) SetExcludeFlags(flags uint16) { qf.excludeFlags = flags }
+func (qf *QueryFilter) SetExcludeFlags(flags uint16) { qf.excludeFlags = flags }
 
 // passFilter returns true if the polygon can be visited.  (I.e. Is traversable.)
 //
@@ -94,7 +94,7 @@ func (qf *DtQueryFilter) SetExcludeFlags(flags uint16) { qf.excludeFlags = flags
 //   ref     The reference id of the polygon test.
 //   tile    The tile containing the polygon.
 //   poly    The polygon to test.
-func (qf *DtQueryFilter) passFilter(ref DtPolyRef, tile *DtMeshTile, poly *DtPoly) bool {
+func (qf *QueryFilter) passFilter(ref PolyRef, tile *MeshTile, poly *Poly) bool {
 	return (poly.Flags&qf.includeFlags) != 0 && (poly.Flags&qf.excludeFlags) == 0
 }
 
@@ -113,10 +113,10 @@ func (qf *DtQueryFilter) passFilter(ref DtPolyRef, tile *DtMeshTile, poly *DtPol
 //   nextRef  The refernece id of the next polygon.
 //   nextTile The tile containing the next polygon.
 //   nextPoly The next polygon.
-func (qf *DtQueryFilter) Cost(pa, pb d3.Vec3,
-	prevRef DtPolyRef, prevTile *DtMeshTile, prevPoly *DtPoly,
-	curRef DtPolyRef, curTile *DtMeshTile, curPoly *DtPoly,
-	nextRef DtPolyRef, nextTile *DtMeshTile, nextPoly *DtPoly) float32 {
+func (qf *QueryFilter) Cost(pa, pb d3.Vec3,
+	prevRef PolyRef, prevTile *MeshTile, prevPoly *Poly,
+	curRef PolyRef, curTile *MeshTile, curPoly *Poly,
+	nextRef PolyRef, nextTile *MeshTile, nextPoly *Poly) float32 {
 
 	return pa.Dist(pb) * qf.areaCost[curPoly.Area()]
 }

--- a/reader.go
+++ b/reader.go
@@ -7,17 +7,17 @@ import (
 	"reflect"
 )
 
-// DtTileRef is a reference to a tile of the navigation mesh.
-type DtTileRef uint32
+// TileRef is a reference to a tile of the navigation mesh.
+type TileRef uint32
 
 type navMeshTileHeader struct {
-	TileRef  DtTileRef
+	TileRef  TileRef
 	DataSize int32
 }
 
 // Decode reads a PNG image from r and returns it as an image.Image.
 // The type of Image returned depends on the PNG contents.
-func Decode(r io.Reader) (*DtNavMesh, error) {
+func Decode(r io.Reader) (*NavMesh, error) {
 	// Read header.
 	var (
 		hdr navMeshSetHeader
@@ -37,9 +37,9 @@ func Decode(r io.Reader) (*DtNavMesh, error) {
 		return nil, fmt.Errorf("wrong version: %d", hdr.Version)
 	}
 
-	var mesh DtNavMesh
+	var mesh NavMesh
 	status := mesh.init(&hdr.Params)
-	if DtStatusFailed(status) {
+	if StatusFailed(status) {
 		return nil, fmt.Errorf("status failed 0x%x", status)
 	}
 
@@ -66,7 +66,7 @@ func Decode(r io.Reader) (*DtNavMesh, error) {
 			return nil, err
 		}
 		status, _ := mesh.addTile(data, tileHdr.DataSize, tileHdr.TileRef)
-		if status&DtFailure != 0 {
+		if status&Failure != 0 {
 			return nil, fmt.Errorf("couldn't add tile %d(), status: 0x%x\n", i, status)
 		}
 	}

--- a/status.go
+++ b/status.go
@@ -2,68 +2,68 @@ package detour
 
 import "fmt"
 
-// DtStatus represents status flags.
-type DtStatus uint32
+// Status represents status flags.
+type Status uint32
 
 // High level status.
 const (
-	DtFailure    DtStatus = 1 << 31 // Operation failed.
-	DtSuccess             = 1 << 30 // Operation succeed.
-	DtInProgress          = 1 << 29 // Operation still in progress.
+	Failure    Status = 1 << 31 // Operation failed.
+	Success           = 1 << 30 // Operation succeed.
+	InProgress        = 1 << 29 // Operation still in progress.
 
 	// Detail information for status.
-	DtStatusDetailMask = 0x0ffffff
-	DtWrongMagic       = 1 << 0 // Input data is not recognized.
-	DtWrongVersion     = 1 << 1 // Input data is in wrong version.
-	DtOutOfMemory      = 1 << 2 // Operation ran out of memory.
-	DtInvalidParam     = 1 << 3 // An input parameter was invalid.
-	DtBufferTooSmall   = 1 << 4 // Result buffer for the query was too small to store all results.
-	DtOutOfNodes       = 1 << 5 // Query ran out of nodes during search.
-	DtPartialResult    = 1 << 6 // Query did not reach the end location, returning best guess.
+	StatusDetailMask = 0x0ffffff
+	WrongMagic       = 1 << 0 // Input data is not recognized.
+	WrongVersion     = 1 << 1 // Input data is in wrong version.
+	OutOfMemory      = 1 << 2 // Operation ran out of memory.
+	InvalidParam     = 1 << 3 // An input parameter was invalid.
+	BufferTooSmall   = 1 << 4 // Result buffer for the query was too small to store all results.
+	OutOfNodes       = 1 << 5 // Query ran out of nodes during search.
+	PartialResult    = 1 << 6 // Query did not reach the end location, returning best guess.
 )
 
 // Implementation of the error interface
-func (s DtStatus) Error() string {
-	if s == DtFailure {
-		switch s & DtStatusDetailMask {
-		case DtWrongMagic:
+func (s Status) Error() string {
+	if s == Failure {
+		switch s & StatusDetailMask {
+		case WrongMagic:
 			return "wrong magic number"
-		case DtWrongVersion:
+		case WrongVersion:
 			return "wrong version number"
-		case DtOutOfMemory:
+		case OutOfMemory:
 			return "out of memory"
-		case DtInvalidParam:
+		case InvalidParam:
 			return "invalid parameter"
-		case DtOutOfNodes:
+		case OutOfNodes:
 			return "out of nodes"
-		case DtPartialResult:
+		case PartialResult:
 			return "partial result"
 		default:
 			return fmt.Sprintf("unspecified error 0x%x", s)
 		}
 	}
-	if s == DtInProgress {
+	if s == InProgress {
 		return "in progress"
 	}
 	return "success"
 }
 
-// DtStatusSucceed returns true if status is success.
-func DtStatusSucceed(status DtStatus) bool {
-	return (status & DtSuccess) != 0
+// StatusSucceed returns true if status is success.
+func StatusSucceed(status Status) bool {
+	return (status & Success) != 0
 }
 
-// DtStatusFailed returns true if status is failure.
-func DtStatusFailed(status DtStatus) bool {
-	return (status & DtFailure) != 0
+// StatusFailed returns true if status is failure.
+func StatusFailed(status Status) bool {
+	return (status & Failure) != 0
 }
 
-// DtStatusInProgress returns true if status is in progress.
-func DtStatusInProgress(status DtStatus) bool {
-	return (status & DtInProgress) != 0
+// StatusInProgress returns true if status is in progress.
+func StatusInProgress(status Status) bool {
+	return (status & InProgress) != 0
 }
 
-// DtStatusDetail returns true if specific detail is set.
-func DtStatusDetail(status DtStatus, detail uint32) bool {
+// StatusDetail returns true if specific detail is set.
+func StatusDetail(status Status, detail uint32) bool {
 	return (uint32(status) & detail) != 0
 }

--- a/structs.go
+++ b/structs.go
@@ -4,15 +4,15 @@ type navMeshSetHeader struct {
 	Magic    int32
 	Version  int32
 	NumTiles int32
-	Params   DtNavMeshParams
+	Params   NavMeshParams
 }
 
-// DtNavMeshParams contains the configuration parameters used to define
+// NavMeshParams contains the configuration parameters used to define
 // multi-tile navigation meshes.
 //
 // The values are used to allocate space during the initialization of a navigation mesh.
-// see dtNavMesh.init()
-type DtNavMeshParams struct {
+// see NavMesh.init()
+type NavMeshParams struct {
 	Orig       [3]float32 // The world space origin of the navigation mesh's tile space. [(x, y, z)]
 	TileWidth  float32    // The width of each tile. (Along the x-axis.)
 	TileHeight float32    // The height of each tile. (Along the z-axis.)
@@ -20,13 +20,13 @@ type DtNavMeshParams struct {
 	MaxPolys   uint32     // The maximum number of polygons each tile can contain.
 }
 
-// DtMeshHeader provides high level information related to a dtMeshTile object.
-type DtMeshHeader struct {
+// MeshHeader provides high level information related to a MeshTile object.
+type MeshHeader struct {
 	Magic           int32      // Tile magic number. (Used to identify the data format.)
 	Version         int32      // Tile data format version number.
-	X               int32      // The x-position of the tile within the dtNavMesh tile grid. (x, y, layer)
-	Y               int32      // The y-position of the tile within the dtNavMesh tile grid. (x, y, layer)
-	Layer           int32      // The layer of the tile within the dtNavMesh tile grid. (x, y, layer)
+	X               int32      // The x-position of the tile within the NavMesh tile grid. (x, y, layer)
+	Y               int32      // The y-position of the tile within the NavMesh tile grid. (x, y, layer)
+	Layer           int32      // The layer of the tile within the NavMesh tile grid. (x, y, layer)
 	UserID          uint32     // The user defined id of the tile.
 	PolyCount       int32      // The number of polygons in the tile.
 	VertCount       int32      // The number of vertices in the tile.
@@ -45,27 +45,27 @@ type DtMeshHeader struct {
 	BvQuantFactor   float32    // The bounding volume quantization factor.
 }
 
-// DtMeshTile defines a navigation mesh tile.
-type DtMeshTile struct {
-	Salt          uint32         // Counter describing modifications to the tile.
-	LinksFreeList uint32         // Index to the next free link.
-	Header        *DtMeshHeader  // The tile header.
-	Polys         []DtPoly       // The tile polygons. [Size: dtMeshHeader.polyCount]
-	Verts         []float32      // The tile vertices. [Size: dtMeshHeader.vertCount]
-	Links         []dtLink       // The tile links. [Size: dtMeshHeader.maxLinkCount]
-	DetailMeshes  []dtPolyDetail // The tile's detail sub-meshes. [Size: dtMeshHeader.detailMeshCount]
-	DetailVerts   []float32      // The detail mesh's unique vertices. [(x, y, z) * dtMeshHeader.detailVertCount]
-	// The detail mesh's triangles. [(vertA, vertB, vertC) * dtMeshHeader.detailTriCount]
+// MeshTile defines a navigation mesh tile.
+type MeshTile struct {
+	Salt          uint32       // Counter describing modifications to the tile.
+	LinksFreeList uint32       // Index to the next free link.
+	Header        *MeshHeader  // The tile header.
+	Polys         []Poly       // The tile polygons. [Size: MeshHeader.polyCount]
+	Verts         []float32    // The tile vertices. [Size: MeshHeader.vertCount]
+	Links         []link       // The tile links. [Size: MeshHeader.maxLinkCount]
+	DetailMeshes  []polyDetail // The tile's detail sub-meshes. [Size: MeshHeader.detailMeshCount]
+	DetailVerts   []float32    // The detail mesh's unique vertices. [(x, y, z) * MeshHeader.detailVertCount]
+	// The detail mesh's triangles. [(vertA, vertB, vertC) * MeshHeader.detailTriCount]
 	DetailTris []uint8
 
-	// The tile bounding volume nodes. [Size: dtMeshHeader.bvNodeCount]
+	// The tile bounding volume nodes. [Size: MeshHeader.bvNodeCount]
 	// (Will be null if bounding volumes are disabled.)
-	BvTree []dtBVNode
-	// The tile off-mesh connections. [Size: dtMeshHeader.offMeshConCount]
-	OffMeshCons []DtOffMeshConnection
+	BvTree []bvNode
+	// The tile off-mesh connections. [Size: MeshHeader.offMeshConCount]
+	OffMeshCons []OffMeshConnection
 
-	Data     []uint8     // The tile data. (Not directly accessed under normal situations.)
-	DataSize int32       // Size of the tile data.
-	Flags    int32       // Tile flags. (See: dtTileFlags)
-	Next     *DtMeshTile // The next free tile, or the next tile in the spatial grid.
+	Data     []uint8   // The tile data. (Not directly accessed under normal situations.)
+	DataSize int32     // Size of the tile data.
+	Flags    int32     // Tile flags. (See: tileFlags)
+	Next     *MeshTile // The next free tile, or the next tile in the spatial grid.
 }

--- a/tile_test.go
+++ b/tile_test.go
@@ -8,14 +8,14 @@ import (
 
 func TestFindNearestPolyInTile(t *testing.T) {
 	var (
-		mesh *DtNavMesh
+		mesh *NavMesh
 		err  error
 	)
 
 	pathTests := []struct {
 		pt   d3.Vec3   // point
 		ext  d3.Vec3   // search extents
-		want DtPolyRef // wanted poly ref
+		want PolyRef // wanted poly ref
 	}{
 		{
 			d3.Vec3{5, 0, 10},


### PR DESCRIPTION
Big renaming in order to have more idiomatic names, comments, etc.
Make `go vet` and `golink` both very happy pieces of software